### PR TITLE
Reference https://github.com/istanbuljs/istanbul-lib-instrument/pull/43

### DIFF
--- a/packages/istanbul-lib-instrument/src/source-coverage.js
+++ b/packages/istanbul-lib-instrument/src/source-coverage.js
@@ -48,7 +48,8 @@ class SourceCoverage extends classes.FileCoverage {
         this.data.fnMap[f] = {
             name: name,
             decl: cloneLocation(decl),
-            loc: cloneLocation(loc)
+            loc: cloneLocation(loc),
+            line: loc.start.line
         };
         this.data.f[f] = 0;
         this.meta.last.f += 1;
@@ -61,7 +62,8 @@ class SourceCoverage extends classes.FileCoverage {
         this.data.branchMap[b] = {
             loc: cloneLocation(loc),
             type: type,
-            locations: []
+            locations: [],
+            line: loc.start.line
         };
         this.meta.last.b += 1;
         return b;


### PR DESCRIPTION
This PR is try to fix empty line number issue in lcov file.
- https://github.com/istanbuljs/istanbul-lib-instrument/issues/14
- https://github.com/istanbuljs/babel-plugin-istanbul/issues/20

This 'line' property is use in
https://github.com/gotwarlost/istanbul/blob/master/lib/report/lcovonly.js#L56
https://github.com/gotwarlost/istanbul/blob/master/lib/report/lcovonly.js#L80