### PR TITLE
fix(windows): preserve escape char of json-summary key path

### DIFF
--- a/packages/istanbul-reports/lib/json-summary/index.js
+++ b/packages/istanbul-reports/lib/json-summary/index.js
@@ -22,9 +22,8 @@ JsonSummaryReport.prototype.writeSummary = function (filePath, sc) {
     } else {
         cw.write(",");
     }
-    cw.write('"');
-    cw.write(filePath);
-    cw.write('": ');
+    cw.write(JSON.stringify(filePath));
+    cw.write(': ');
     cw.write(JSON.stringify(sc));
     cw.println("");
 };


### PR DESCRIPTION
Copied from https://github.com/istanbuljs-archived-repos/istanbul-reports/pull/20