### PR TITLE
Add possibility to filter coverage maps on absolute filename

### DIFF
--- a/packages/istanbul-lib-coverage/lib/coverage-map.js
+++ b/packages/istanbul-lib-coverage/lib/coverage-map.js
@@ -59,8 +59,9 @@ CoverageMap.prototype.merge = function (obj) {
 };
 /**
  * filter the coveragemap based on the callback provided
- * @param {Function (filename)} callback - Returns true if the should be
- *  include in the coveragemap. False if it should be removed.
+ * @param {Function (filename)} callback - Returns true if the path
+ *  should be included in the coveragemap. False if it should be
+ *  removed.
  */
 CoverageMap.prototype.filter = function (callback) {
      var that = this;

--- a/packages/istanbul-lib-coverage/lib/coverage-map.js
+++ b/packages/istanbul-lib-coverage/lib/coverage-map.js
@@ -58,6 +58,19 @@ CoverageMap.prototype.merge = function (obj) {
     });
 };
 /**
+ * filter the coveragemap based on the callback provided
+ * @param {Function (filename)} callback - Returns true if the should be
+ *  include in the coveragemap. False if it should be removed.
+ */
+CoverageMap.prototype.filter = function (callback) {
+     var that = this;
+     Object.keys(that.data).forEach(function (k) {
+         if (!callback(k)) {
+             delete that.data[k];
+         }
+     });
+};
+/**
  * returns a JSON-serializable POJO for this coverage map
  * @returns {Object}
  */

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -9,6 +9,7 @@ function TestExclude (opts) {
   assign(this, {
     cwd: process.cwd(),
     include: false,
+    relativePath: true,
     configKey: null, // the key to load config from in package.json.
     configPath: null, // optionally override requireMainFilename.
     configFound: false
@@ -55,13 +56,18 @@ TestExclude.prototype.removeNegatedModuleExclude = function () {
 }
 
 TestExclude.prototype.shouldInstrument = function (filename, relFile) {
-  relFile = relFile || path.relative(this.cwd, filename)
+  var pathToCheck = filename
 
-  // Don't instrument files that are outside of the current working directory.
-  if (/^\.\./.test(path.relative(this.cwd, filename))) return false
+  if (this.relativePath) {
+    relFile = relFile || path.relative(this.cwd, filename)
 
-  relFile = relFile.replace(/^\.[\\/]/, '') // remove leading './' or '.\'.
-  return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
+    // Don't instrument files that are outside of the current working directory.
+    if (/^\.\./.test(path.relative(this.cwd, filename))) return false
+
+    pathToCheck = relFile.replace(/^\.[\\/]/, '') // remove leading './' or '.\'.
+  }
+
+  return (!this.include || micromatch.any(pathToCheck, this.include, {dotfiles: true})) && !micromatch.any(pathToCheck, this.exclude, {dotfiles: true})
 }
 
 TestExclude.prototype.pkgConf = function (key, path) {


### PR DESCRIPTION
As discussed, previous changes redone in the mono-repo and introduced a parameter/flag in stead of a separate module.

The problem I try to resolve:
I've a 'non-standard' setup, where I build my distribution-packages outside of the source folder. I do this because I write mainly ES6 code, and distribution-packages need to be plain old JavaScript. In addition because AVA is perfectly able to run ES6 tests, but not able to test ES6 modules I've to transpile my ES6 code (using rollup and babel/bublé) to plain JavaScript. The resulting transpiled file will also include all libraries being `import`ed.

The indication source files and line missing coverage works perfectly, using sourcemaps. However in the sourcemaps the original full paths are included. So if I run `nyc` with an include or exclude filter the I only have 2 options: show the coverage of all modules (including external modules, which I didn't intend to be instrumented to be covered), or no modules at all, because all of the sourcemaps absolute paths are outside of the current directory. 

Therefore I introduced these methods, which I intend to use from `nyc` (either by having the `--report` flag taking a different or by introducing a flag (`--no-relativepath`, `--absolutepath` or something similar).

Now writing this all down, a solution might be to first have `nyc` do its work, including generating the report-dir, but no output. Changing to the original source directory again and invoking `nyc --report --report-dir=<report-dir>`. I've to validate this works.