### PR TITLE
feat: pull in debug module, to make debug messages optional

### DIFF
--- a/packages/istanbul-lib-source-maps/README.md
+++ b/packages/istanbul-lib-source-maps/README.md
@@ -4,4 +4,10 @@ istanbul-lib-source-maps
 [![Greenkeeper badge](https://badges.greenkeeper.io/istanbuljs/istanbul-lib-source-maps.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/istanbuljs/istanbul-lib-source-maps.svg)](https://travis-ci.org/istanbuljs/istanbul-lib-source-maps)
 
-Source map support for istanbul. Extremely immature at this point.
+Source map support for istanbuljs.
+
+## Debugging
+
+_istanbul-lib-source-maps_ uses the [debug](https://www.npmjs.com/package/debug) module.
+Run your application with the environment variable `DEBUG=istanbuljs`, to receive debug
+output.

--- a/packages/istanbul-lib-source-maps/README.md
+++ b/packages/istanbul-lib-source-maps/README.md
@@ -1,8 +1,7 @@
 istanbul-lib-source-maps
 ========================
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/istanbuljs/istanbul-lib-source-maps.svg)](https://greenkeeper.io/)
-[![Build Status](https://travis-ci.org/istanbuljs/istanbul-lib-source-maps.svg)](https://travis-ci.org/istanbuljs/istanbul-lib-source-maps)
+[![Build Status](https://travis-ci.org/istanbuljs/istanbuljs.svg?branch=master)](https://travis-ci.org/istanbuljs/istanbuljs)
 
 Source map support for istanbuljs.
 

--- a/packages/istanbul-lib-source-maps/lib/map-store.js
+++ b/packages/istanbul-lib-source-maps/lib/map-store.js
@@ -4,7 +4,8 @@
  */
 "use strict";
 
-var path = require('path'),
+var debug = require('debug')('istanbuljs'),
+    path = require('path'),
     fs = require('fs'),
     pathutils = require('./pathutils'),
     sourceStore = require('./source-store'),
@@ -51,7 +52,7 @@ MapStore.prototype.registerURL = function (transformedFilePath, sourceMapUrl) {
                 data: sourceMapUrl.substring(pos + b64.length)
             };
         } else {
-            console.error('Unable to interpret source map URL: ', sourceMapUrl);
+            debug('Unable to interpret source map URL: ' + sourceMapUrl);
         }
         return;
     }
@@ -69,7 +70,7 @@ MapStore.prototype.registerMap = function (transformedFilePath, sourceMap) {
     if (sourceMap && sourceMap.version) {
         this.data[transformedFilePath] = { type: 'object', data: sourceMap };
     } else {
-        console.error('Invalid source map object', sourceMap);
+        debug('Invalid source map object:' + JSON.stringify(sourceMap, null, 2));
     }
 };
 /**
@@ -135,11 +136,8 @@ MapStore.prototype.transformCoverage = function (coverageMap) {
             });
             return smc;
         } catch (ex) {
-            console.error('Error returning source map for ' + filePath);
-            console.error(ex.message || ex);
-            if (this.verbose) {
-                console.error(ex.stack);
-            }
+            debug('Error returning source map for ' + filePath);
+            debug(ex.stack);
             return null;
         }
     }).transform(coverageMap);
@@ -160,4 +158,3 @@ MapStore.prototype.dispose = function () {
 module.exports = {
     MapStore: MapStore
 };
-

--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -4,7 +4,8 @@
  */
 "use strict";
 
-var pathutils = require('./pathutils'),
+var debug = require('debug')('istanbuljs'),
+    pathutils = require('./pathutils'),
     libCoverage = require('istanbul-lib-coverage'),
     MappedCoverage = require('./mapped').MappedCoverage;
 
@@ -19,7 +20,7 @@ function isInvalidPosition (pos) {
  * @returns {Object} the remapped location Object
  */
 function getMapping(sourceMap, location, origFile) {
- 
+
     if (!location) {
         return null;
     }
@@ -167,7 +168,7 @@ SourceMapTransformer.prototype.transform = function (coverageMap) {
 
         changed = that.processFile(fc, sourceMap, getMappedCoverage);
         if (!changed) {
-            console.warn('File [' + file + '] ignored, nothing could be mapped');
+            debug('File [' + file + '] ignored, nothing could be mapped');
         }
     });
     return libCoverage.createCoverageMap(output);
@@ -178,5 +179,3 @@ module.exports = {
         return new SourceMapTransformer(finder, opts);
     }
 };
-
-

--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -13,6 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "debug": "^2.6.3",
     "istanbul-lib-coverage": "^1.0.2",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.4",


### PR DESCRIPTION
based on @ben-eb's suggestion, switch to using `debug` module, rather than spitting out messages to `stdout`.

fixes #27 

