### PR TITLE
istanbuljs/istanbuljs#42 - Add failing test for Cobertura reporter branchMap structure

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file.js
+++ b/packages/istanbul-lib-coverage/lib/file.js
@@ -204,7 +204,7 @@ FileCoverage.prototype.getBranchCoverageByLine = function () {
         branches = this.b,
         ret = {};
     Object.keys(branchMap).forEach(function (k) {
-        var line = branchMap[k].line,
+        var line = branchMap[k].line || branchMap[k].loc.start.line,
             branchData = branches[k];
         ret[line] = ret[line] || [];
         ret[line].push.apply(ret[line], branchData);

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -319,4 +319,41 @@ describe('base coverage', function () {
             }
         }, bcby);
     });
+
+    it('returns branch coverage by line with Cobertura branchMap structure', function () {
+        var loc = function (sl, sc, el, ec) {
+                return {
+                    start: {line: sl, column: sc},
+                    end: {line: el, column: ec}
+                };
+            },
+            c = new FileCoverage({
+                path: '/path/to/file',
+                branchMap: {
+                    1: {loc: loc(1,1,1,100)},
+                    2: {loc: loc(2,50,2,100)}
+                },
+                fnMap: {},
+                statementMap: {},
+                s: {},
+                b: {
+                    1: [1, 0],
+                    2: [0, 0, 0, 1]
+                },
+                f: {}
+            }),
+            bcby = c.getBranchCoverageByLine();
+        assert.deepEqual({
+            1: {
+                covered: 1,
+                total: 2,
+                coverage: 50
+            },
+            2: {
+                covered: 1,
+                total: 4,
+                coverage: 25
+            }
+        }, bcby);
+    });
 });


### PR DESCRIPTION
#42 
This branchMap structure is used by both the Cobertura and  the Clover reporters. A fix would add accurate conditional coverage to both.