### PR TITLE
feat: once 100% line coverage is achieved, missing branch coverage is now shown in text report

### DIFF
--- a/packages/istanbul-lib-report/lib/file-writer.js
+++ b/packages/istanbul-lib-report/lib/file-writer.js
@@ -84,8 +84,15 @@ function ConsoleWriter() {
 }
 util.inherits(ConsoleWriter, ContentWriter);
 
+// allow stdout to be captured for tests.
+var capture = false;
+var output = '';
 ConsoleWriter.prototype.write = function (str) {
-    process.stdout.write(str);
+    if (capture) {
+        output += str;
+    } else {
+        process.stdout.write(str);
+    }
 };
 
 ConsoleWriter.prototype.colorize = function (str, clazz) {
@@ -115,6 +122,24 @@ function FileWriter(baseDir) {
     mkdirp.sync(baseDir);
     this.baseDir = baseDir;
 }
+
+/**
+* static helpers for capturing stdout report output;
+* super useful for tests!
+*/
+FileWriter.startCapture = function () {
+  capture = true;
+};
+FileWriter.stopCapture = function () {
+  capture = false;
+};
+FileWriter.getOutput = function () {
+  return output;
+};
+FileWriter.resetOutput = function () {
+  output = '';
+};
+
 /**
  * returns a FileWriter that is rooted at the supplied subdirectory
  * @param {String} subdir the subdirectory under which to root the

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "is-windows": "^1.0.1",
     "istanbul-lib-coverage": "^1.0.2",
     "istanbul-lib-report": "^1.0.0",
     "jshint": "^2.8.0",

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "istanbul-lib-coverage": "^1.0.2",
+    "istanbul-lib-report": "^1.0.0",
     "jshint": "^2.8.0",
     "mocha": "^3.1.2"
   },

--- a/packages/istanbul-reports/test/fixtures/specs/100-line-100-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/100-line-100-branch.json
@@ -1,0 +1,1527 @@
+{
+  "title": "handles 100% branch and line coverage",
+  "textReportExpected": "----------|----------|----------|----------|----------|----------------|\nFile      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |\n----------|----------|----------|----------|----------|----------------|\n\u001b[32;1mAll files\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[33;1m               \u001b[0m |\n\u001b[32;1m index.js\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[33;1m               \u001b[0m |\n----------|----------|----------|----------|----------|----------------|\n",
+  "map": {
+    "/Users/benjamincoe/oss/test-exclude/index.js": {
+      "path": "/Users/benjamincoe/oss/test-exclude/index.js",
+      "statementMap": {
+        "0": {
+          "start": {
+            "line": 1,
+            "column": 15
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        },
+        "1": {
+          "start": {
+            "line": 2,
+            "column": 15
+          },
+          "end": {
+            "line": 2,
+            "column": 32
+          }
+        },
+        "2": {
+          "start": {
+            "line": 3,
+            "column": 19
+          },
+          "end": {
+            "line": 3,
+            "column": 40
+          }
+        },
+        "3": {
+          "start": {
+            "line": 4,
+            "column": 13
+          },
+          "end": {
+            "line": 4,
+            "column": 28
+          }
+        },
+        "4": {
+          "start": {
+            "line": 5,
+            "column": 18
+          },
+          "end": {
+            "line": 5,
+            "column": 40
+          }
+        },
+        "5": {
+          "start": {
+            "line": 13,
+            "column": 2
+          },
+          "end": {
+            "line": 19,
+            "column": 10
+          }
+        },
+        "6": {
+          "start": {
+            "line": 21,
+            "column": 2
+          },
+          "end": {
+            "line": 21,
+            "column": 69
+          }
+        },
+        "7": {
+          "start": {
+            "line": 21,
+            "column": 40
+          },
+          "end": {
+            "line": 21,
+            "column": 69
+          }
+        },
+        "8": {
+          "start": {
+            "line": 22,
+            "column": 2
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "9": {
+          "start": {
+            "line": 22,
+            "column": 40
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "10": {
+          "start": {
+            "line": 24,
+            "column": 2
+          },
+          "end": {
+            "line": 26,
+            "column": 3
+          }
+        },
+        "11": {
+          "start": {
+            "line": 25,
+            "column": 4
+          },
+          "end": {
+            "line": 25,
+            "column": 63
+          }
+        },
+        "12": {
+          "start": {
+            "line": 28,
+            "column": 2
+          },
+          "end": {
+            "line": 30,
+            "column": 3
+          }
+        },
+        "13": {
+          "start": {
+            "line": 29,
+            "column": 4
+          },
+          "end": {
+            "line": 29,
+            "column": 44
+          }
+        },
+        "14": {
+          "start": {
+            "line": 32,
+            "column": 2
+          },
+          "end": {
+            "line": 36,
+            "column": 3
+          }
+        },
+        "15": {
+          "start": {
+            "line": 33,
+            "column": 4
+          },
+          "end": {
+            "line": 33,
+            "column": 57
+          }
+        },
+        "16": {
+          "start": {
+            "line": 35,
+            "column": 4
+          },
+          "end": {
+            "line": 35,
+            "column": 24
+          }
+        },
+        "17": {
+          "start": {
+            "line": 38,
+            "column": 2
+          },
+          "end": {
+            "line": 40,
+            "column": 3
+          }
+        },
+        "18": {
+          "start": {
+            "line": 39,
+            "column": 4
+          },
+          "end": {
+            "line": 39,
+            "column": 43
+          }
+        },
+        "19": {
+          "start": {
+            "line": 42,
+            "column": 2
+          },
+          "end": {
+            "line": 44,
+            "column": 3
+          }
+        },
+        "20": {
+          "start": {
+            "line": 50,
+            "column": 0
+          },
+          "end": {
+            "line": 59,
+            "column": 1
+          }
+        },
+        "21": {
+          "start": {
+            "line": 51,
+            "column": 29
+          },
+          "end": {
+            "line": 51,
+            "column": 34
+          }
+        },
+        "22": {
+          "start": {
+            "line": 52,
+            "column": 2
+          },
+          "end": {
+            "line": 57,
+            "column": 4
+          }
+        },
+        "23": {
+          "start": {
+            "line": 53,
+            "column": 18
+          },
+          "end": {
+            "line": 54,
+            "column": 71
+          }
+        },
+        "24": {
+          "start": {
+            "line": 55,
+            "column": 4
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "25": {
+          "start": {
+            "line": 55,
+            "column": 17
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "26": {
+          "start": {
+            "line": 56,
+            "column": 4
+          },
+          "end": {
+            "line": 56,
+            "column": 19
+          }
+        },
+        "27": {
+          "start": {
+            "line": 58,
+            "column": 2
+          },
+          "end": {
+            "line": 58,
+            "column": 29
+          }
+        },
+        "28": {
+          "start": {
+            "line": 61,
+            "column": 0
+          },
+          "end": {
+            "line": 69,
+            "column": 1
+          }
+        },
+        "29": {
+          "start": {
+            "line": 62,
+            "column": 2
+          },
+          "end": {
+            "line": 62,
+            "column": 56
+          }
+        },
+        "30": {
+          "start": {
+            "line": 65,
+            "column": 2
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "31": {
+          "start": {
+            "line": 65,
+            "column": 55
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "32": {
+          "start": {
+            "line": 67,
+            "column": 2
+          },
+          "end": {
+            "line": 67,
+            "column": 43
+          }
+        },
+        "33": {
+          "start": {
+            "line": 68,
+            "column": 2
+          },
+          "end": {
+            "line": 68,
+            "column": 143
+          }
+        },
+        "34": {
+          "start": {
+            "line": 71,
+            "column": 0
+          },
+          "end": {
+            "line": 82,
+            "column": 1
+          }
+        },
+        "35": {
+          "start": {
+            "line": 72,
+            "column": 14
+          },
+          "end": {
+            "line": 74,
+            "column": 4
+          }
+        },
+        "36": {
+          "start": {
+            "line": 76,
+            "column": 2
+          },
+          "end": {
+            "line": 81,
+            "column": 3
+          }
+        },
+        "37": {
+          "start": {
+            "line": 77,
+            "column": 4
+          },
+          "end": {
+            "line": 77,
+            "column": 27
+          }
+        },
+        "38": {
+          "start": {
+            "line": 78,
+            "column": 4
+          },
+          "end": {
+            "line": 78,
+            "column": 23
+          }
+        },
+        "39": {
+          "start": {
+            "line": 80,
+            "column": 4
+          },
+          "end": {
+            "line": 80,
+            "column": 13
+          }
+        },
+        "40": {
+          "start": {
+            "line": 85,
+            "column": 2
+          },
+          "end": {
+            "line": 97,
+            "column": 8
+          }
+        },
+        "41": {
+          "start": {
+            "line": 87,
+            "column": 4
+          },
+          "end": {
+            "line": 89,
+            "column": 5
+          }
+        },
+        "42": {
+          "start": {
+            "line": 88,
+            "column": 6
+          },
+          "end": {
+            "line": 88,
+            "column": 64
+          }
+        },
+        "43": {
+          "start": {
+            "line": 92,
+            "column": 4
+          },
+          "end": {
+            "line": 94,
+            "column": 5
+          }
+        },
+        "44": {
+          "start": {
+            "line": 93,
+            "column": 6
+          },
+          "end": {
+            "line": 93,
+            "column": 60
+          }
+        },
+        "45": {
+          "start": {
+            "line": 96,
+            "column": 4
+          },
+          "end": {
+            "line": 96,
+            "column": 33
+          }
+        },
+        "46": {
+          "start": {
+            "line": 100,
+            "column": 17
+          },
+          "end": {
+            "line": 102,
+            "column": 1
+          }
+        },
+        "47": {
+          "start": {
+            "line": 101,
+            "column": 2
+          },
+          "end": {
+            "line": 101,
+            "column": 30
+          }
+        },
+        "48": {
+          "start": {
+            "line": 104,
+            "column": 0
+          },
+          "end": {
+            "line": 111,
+            "column": 1
+          }
+        },
+        "49": {
+          "start": {
+            "line": 113,
+            "column": 0
+          },
+          "end": {
+            "line": 113,
+            "column": 27
+          }
+        }
+      },
+      "fnMap": {
+        "0": {
+          "name": "TestExclude",
+          "decl": {
+            "start": {
+              "line": 12,
+              "column": 9
+            },
+            "end": {
+              "line": 12,
+              "column": 20
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 28
+            },
+            "end": {
+              "line": 45,
+              "column": 1
+            }
+          },
+          "line": 12
+        },
+        "1": {
+          "name": "(anonymous_1)",
+          "decl": {
+            "start": {
+              "line": 50,
+              "column": 51
+            },
+            "end": {
+              "line": 50,
+              "column": 52
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 50,
+              "column": 63
+            },
+            "end": {
+              "line": 59,
+              "column": 1
+            }
+          },
+          "line": 50
+        },
+        "2": {
+          "name": "(anonymous_2)",
+          "decl": {
+            "start": {
+              "line": 52,
+              "column": 37
+            },
+            "end": {
+              "line": 52,
+              "column": 38
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 52,
+              "column": 50
+            },
+            "end": {
+              "line": 57,
+              "column": 3
+            }
+          },
+          "line": 52
+        },
+        "3": {
+          "name": "(anonymous_3)",
+          "decl": {
+            "start": {
+              "line": 61,
+              "column": 41
+            },
+            "end": {
+              "line": 61,
+              "column": 42
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 61,
+              "column": 70
+            },
+            "end": {
+              "line": 69,
+              "column": 1
+            }
+          },
+          "line": 61
+        },
+        "4": {
+          "name": "(anonymous_4)",
+          "decl": {
+            "start": {
+              "line": 71,
+              "column": 32
+            },
+            "end": {
+              "line": 71,
+              "column": 33
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 71,
+              "column": 53
+            },
+            "end": {
+              "line": 82,
+              "column": 1
+            }
+          },
+          "line": 71
+        },
+        "5": {
+          "name": "prepGlobPatterns",
+          "decl": {
+            "start": {
+              "line": 84,
+              "column": 9
+            },
+            "end": {
+              "line": 84,
+              "column": 25
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 84,
+              "column": 37
+            },
+            "end": {
+              "line": 98,
+              "column": 1
+            }
+          },
+          "line": 84
+        },
+        "6": {
+          "name": "(anonymous_6)",
+          "decl": {
+            "start": {
+              "line": 85,
+              "column": 25
+            },
+            "end": {
+              "line": 85,
+              "column": 26
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 85,
+              "column": 52
+            },
+            "end": {
+              "line": 97,
+              "column": 3
+            }
+          },
+          "line": 85
+        },
+        "7": {
+          "name": "(anonymous_7)",
+          "decl": {
+            "start": {
+              "line": 100,
+              "column": 17
+            },
+            "end": {
+              "line": 100,
+              "column": 18
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 100,
+              "column": 33
+            },
+            "end": {
+              "line": 102,
+              "column": 1
+            }
+          },
+          "line": 100
+        }
+      },
+      "branchMap": {
+        "0": {
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 2
+            },
+            "end": {
+              "line": 21,
+              "column": 69
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 69
+              }
+            }
+          ],
+          "line": 21
+        },
+        "1": {
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 2
+            },
+            "end": {
+              "line": 22,
+              "column": 69
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            }
+          ],
+          "line": 22
+        },
+        "2": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 2
+            },
+            "end": {
+              "line": 26,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            }
+          ],
+          "line": 24
+        },
+        "3": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 6
+            },
+            "end": {
+              "line": 24,
+              "column": 54
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 6
+              },
+              "end": {
+                "line": 24,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 23
+              },
+              "end": {
+                "line": 24,
+                "column": 36
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 40
+              },
+              "end": {
+                "line": 24,
+                "column": 54
+              }
+            }
+          ],
+          "line": 24
+        },
+        "4": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 30,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            }
+          ],
+          "line": 28
+        },
+        "5": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 6
+            },
+            "end": {
+              "line": 28,
+              "column": 51
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 6
+              },
+              "end": {
+                "line": 28,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 23
+              },
+              "end": {
+                "line": 28,
+                "column": 51
+              }
+            }
+          ],
+          "line": 28
+        },
+        "6": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 2
+            },
+            "end": {
+              "line": 36,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            }
+          ],
+          "line": 32
+        },
+        "7": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 6
+            },
+            "end": {
+              "line": 32,
+              "column": 45
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 6
+              },
+              "end": {
+                "line": 32,
+                "column": 18
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 22
+              },
+              "end": {
+                "line": 32,
+                "column": 45
+              }
+            }
+          ],
+          "line": 32
+        },
+        "8": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 2
+            },
+            "end": {
+              "line": 40,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            }
+          ],
+          "line": 38
+        },
+        "9": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 6
+            },
+            "end": {
+              "line": 38,
+              "column": 93
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 6
+              },
+              "end": {
+                "line": 38,
+                "column": 40
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 44
+              },
+              "end": {
+                "line": 38,
+                "column": 93
+              }
+            }
+          ],
+          "line": 38
+        },
+        "10": {
+          "loc": {
+            "start": {
+              "line": 55,
+              "column": 4
+            },
+            "end": {
+              "line": 55,
+              "column": 44
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            },
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            }
+          ],
+          "line": 55
+        },
+        "11": {
+          "loc": {
+            "start": {
+              "line": 62,
+              "column": 12
+            },
+            "end": {
+              "line": 62,
+              "column": 56
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 62,
+                "column": 12
+              },
+              "end": {
+                "line": 62,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 62,
+                "column": 23
+              },
+              "end": {
+                "line": 62,
+                "column": 56
+              }
+            }
+          ],
+          "line": 62
+        },
+        "12": {
+          "loc": {
+            "start": {
+              "line": 65,
+              "column": 2
+            },
+            "end": {
+              "line": 65,
+              "column": 67
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            },
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            }
+          ],
+          "line": 65
+        },
+        "13": {
+          "loc": {
+            "start": {
+              "line": 68,
+              "column": 9
+            },
+            "end": {
+              "line": 68,
+              "column": 143
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 68,
+                "column": 10
+              },
+              "end": {
+                "line": 68,
+                "column": 23
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 27
+              },
+              "end": {
+                "line": 68,
+                "column": 82
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 87
+              },
+              "end": {
+                "line": 68,
+                "column": 143
+              }
+            }
+          ],
+          "line": 68
+        },
+        "14": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            }
+          ],
+          "line": 76
+        },
+        "15": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 6
+            },
+            "end": {
+              "line": 76,
+              "column": 65
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 6
+              },
+              "end": {
+                "line": 76,
+                "column": 13
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 17
+              },
+              "end": {
+                "line": 76,
+                "column": 29
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 33
+              },
+              "end": {
+                "line": 76,
+                "column": 65
+              }
+            }
+          ],
+          "line": 76
+        },
+        "16": {
+          "loc": {
+            "start": {
+              "line": 87,
+              "column": 4
+            },
+            "end": {
+              "line": 89,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            }
+          ],
+          "line": 87
+        },
+        "17": {
+          "loc": {
+            "start": {
+              "line": 92,
+              "column": 4
+            },
+            "end": {
+              "line": 94,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            }
+          ],
+          "line": 92
+        }
+      },
+      "s": {
+        "0": 1,
+        "1": 1,
+        "2": 1,
+        "3": 1,
+        "4": 1,
+        "5": 21,
+        "6": 21,
+        "7": 1,
+        "8": 21,
+        "9": 1,
+        "10": 21,
+        "11": 7,
+        "12": 21,
+        "13": 15,
+        "14": 21,
+        "15": 5,
+        "16": 16,
+        "17": 21,
+        "18": 5,
+        "19": 21,
+        "20": 1,
+        "21": 21,
+        "22": 21,
+        "23": 95,
+        "24": 95,
+        "25": 1,
+        "26": 95,
+        "27": 21,
+        "28": 1,
+        "29": 56,
+        "30": 56,
+        "31": 1,
+        "32": 55,
+        "33": 55,
+        "34": 1,
+        "35": 7,
+        "36": 7,
+        "37": 6,
+        "38": 6,
+        "39": 1,
+        "40": 26,
+        "41": 105,
+        "42": 39,
+        "43": 105,
+        "44": 50,
+        "45": 105,
+        "46": 1,
+        "47": 21,
+        "48": 1,
+        "49": 1
+      },
+      "f": {
+        "0": 21,
+        "1": 21,
+        "2": 95,
+        "3": 56,
+        "4": 7,
+        "5": 26,
+        "6": 105,
+        "7": 21
+      },
+      "b": {
+        "0": [
+          1,
+          20
+        ],
+        "1": [
+          1,
+          20
+        ],
+        "2": [
+          7,
+          14
+        ],
+        "3": [
+          21,
+          18,
+          15
+        ],
+        "4": [
+          15,
+          6
+        ],
+        "5": [
+          21,
+          8
+        ],
+        "6": [
+          5,
+          16
+        ],
+        "7": [
+          21,
+          5
+        ],
+        "8": [
+          5,
+          16
+        ],
+        "9": [
+          21,
+          20
+        ],
+        "10": [
+          1,
+          94
+        ],
+        "11": [
+          56,
+          56
+        ],
+        "12": [
+          1,
+          55
+        ],
+        "13": [
+          55,
+          15,
+          50
+        ],
+        "14": [
+          6,
+          1
+        ],
+        "15": [
+          7,
+          7,
+          6
+        ],
+        "16": [
+          39,
+          66
+        ],
+        "17": [
+          50,
+          55
+        ]
+      },
+      "_coverageSchema": "332fd63041d2c1bcb487cc26dd0d5f7d97098a6c",
+      "hash": "f0eaad492c44d3d23e7443abdfe6e8eee863a9ca",
+      "contentHash": "1aadbafa9aec3c6d5ff348fb7143ba8e_10.2.0"
+    }
+  }
+}

--- a/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
@@ -1,0 +1,1607 @@
+{
+  "title": "100% line coverage, missing branch coverage",
+  "textReportExpected": "----------|----------|----------|----------|----------|----------------|\nFile      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |\n----------|----------|----------|----------|----------|----------------|\n\u001b[32;1mAll files\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m    95.35\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[33;1m               \u001b[0m |\n\u001b[32;1m index.js\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m    95.35\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[32;1m      100\u001b[0m |\u001b[33;1m          21,29\u001b[0m |\n----------|----------|----------|----------|----------|----------------|\n",
+  "map": {
+    "/Users/benjamincoe/oss/test-exclude/index.js": {
+      "path": "/Users/benjamincoe/oss/test-exclude/index.js",
+      "statementMap": {
+        "0": {
+          "start": {
+            "line": 1,
+            "column": 15
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        },
+        "1": {
+          "start": {
+            "line": 2,
+            "column": 15
+          },
+          "end": {
+            "line": 2,
+            "column": 32
+          }
+        },
+        "2": {
+          "start": {
+            "line": 3,
+            "column": 19
+          },
+          "end": {
+            "line": 3,
+            "column": 40
+          }
+        },
+        "3": {
+          "start": {
+            "line": 4,
+            "column": 13
+          },
+          "end": {
+            "line": 4,
+            "column": 28
+          }
+        },
+        "4": {
+          "start": {
+            "line": 5,
+            "column": 18
+          },
+          "end": {
+            "line": 5,
+            "column": 40
+          }
+        },
+        "5": {
+          "start": {
+            "line": 13,
+            "column": 2
+          },
+          "end": {
+            "line": 19,
+            "column": 10
+          }
+        },
+        "6": {
+          "start": {
+            "line": 21,
+            "column": 2
+          },
+          "end": {
+            "line": 21,
+            "column": 81
+          }
+        },
+        "7": {
+          "start": {
+            "line": 21,
+            "column": 40
+          },
+          "end": {
+            "line": 21,
+            "column": 81
+          }
+        },
+        "8": {
+          "start": {
+            "line": 22,
+            "column": 2
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "9": {
+          "start": {
+            "line": 22,
+            "column": 40
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "10": {
+          "start": {
+            "line": 24,
+            "column": 2
+          },
+          "end": {
+            "line": 26,
+            "column": 3
+          }
+        },
+        "11": {
+          "start": {
+            "line": 25,
+            "column": 4
+          },
+          "end": {
+            "line": 25,
+            "column": 63
+          }
+        },
+        "12": {
+          "start": {
+            "line": 28,
+            "column": 2
+          },
+          "end": {
+            "line": 30,
+            "column": 3
+          }
+        },
+        "13": {
+          "start": {
+            "line": 29,
+            "column": 4
+          },
+          "end": {
+            "line": 29,
+            "column": 54
+          }
+        },
+        "14": {
+          "start": {
+            "line": 32,
+            "column": 2
+          },
+          "end": {
+            "line": 36,
+            "column": 3
+          }
+        },
+        "15": {
+          "start": {
+            "line": 33,
+            "column": 4
+          },
+          "end": {
+            "line": 33,
+            "column": 57
+          }
+        },
+        "16": {
+          "start": {
+            "line": 35,
+            "column": 4
+          },
+          "end": {
+            "line": 35,
+            "column": 24
+          }
+        },
+        "17": {
+          "start": {
+            "line": 38,
+            "column": 2
+          },
+          "end": {
+            "line": 40,
+            "column": 3
+          }
+        },
+        "18": {
+          "start": {
+            "line": 39,
+            "column": 4
+          },
+          "end": {
+            "line": 39,
+            "column": 43
+          }
+        },
+        "19": {
+          "start": {
+            "line": 42,
+            "column": 2
+          },
+          "end": {
+            "line": 44,
+            "column": 3
+          }
+        },
+        "20": {
+          "start": {
+            "line": 50,
+            "column": 0
+          },
+          "end": {
+            "line": 59,
+            "column": 1
+          }
+        },
+        "21": {
+          "start": {
+            "line": 51,
+            "column": 29
+          },
+          "end": {
+            "line": 51,
+            "column": 34
+          }
+        },
+        "22": {
+          "start": {
+            "line": 52,
+            "column": 2
+          },
+          "end": {
+            "line": 57,
+            "column": 4
+          }
+        },
+        "23": {
+          "start": {
+            "line": 53,
+            "column": 18
+          },
+          "end": {
+            "line": 54,
+            "column": 71
+          }
+        },
+        "24": {
+          "start": {
+            "line": 55,
+            "column": 4
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "25": {
+          "start": {
+            "line": 55,
+            "column": 17
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "26": {
+          "start": {
+            "line": 56,
+            "column": 4
+          },
+          "end": {
+            "line": 56,
+            "column": 19
+          }
+        },
+        "27": {
+          "start": {
+            "line": 58,
+            "column": 2
+          },
+          "end": {
+            "line": 58,
+            "column": 29
+          }
+        },
+        "28": {
+          "start": {
+            "line": 61,
+            "column": 0
+          },
+          "end": {
+            "line": 69,
+            "column": 1
+          }
+        },
+        "29": {
+          "start": {
+            "line": 62,
+            "column": 2
+          },
+          "end": {
+            "line": 62,
+            "column": 56
+          }
+        },
+        "30": {
+          "start": {
+            "line": 65,
+            "column": 2
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "31": {
+          "start": {
+            "line": 65,
+            "column": 55
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "32": {
+          "start": {
+            "line": 67,
+            "column": 2
+          },
+          "end": {
+            "line": 67,
+            "column": 43
+          }
+        },
+        "33": {
+          "start": {
+            "line": 68,
+            "column": 2
+          },
+          "end": {
+            "line": 68,
+            "column": 143
+          }
+        },
+        "34": {
+          "start": {
+            "line": 71,
+            "column": 0
+          },
+          "end": {
+            "line": 82,
+            "column": 1
+          }
+        },
+        "35": {
+          "start": {
+            "line": 72,
+            "column": 14
+          },
+          "end": {
+            "line": 74,
+            "column": 4
+          }
+        },
+        "36": {
+          "start": {
+            "line": 76,
+            "column": 2
+          },
+          "end": {
+            "line": 81,
+            "column": 3
+          }
+        },
+        "37": {
+          "start": {
+            "line": 77,
+            "column": 4
+          },
+          "end": {
+            "line": 77,
+            "column": 27
+          }
+        },
+        "38": {
+          "start": {
+            "line": 78,
+            "column": 4
+          },
+          "end": {
+            "line": 78,
+            "column": 23
+          }
+        },
+        "39": {
+          "start": {
+            "line": 80,
+            "column": 4
+          },
+          "end": {
+            "line": 80,
+            "column": 13
+          }
+        },
+        "40": {
+          "start": {
+            "line": 85,
+            "column": 2
+          },
+          "end": {
+            "line": 97,
+            "column": 8
+          }
+        },
+        "41": {
+          "start": {
+            "line": 87,
+            "column": 4
+          },
+          "end": {
+            "line": 89,
+            "column": 5
+          }
+        },
+        "42": {
+          "start": {
+            "line": 88,
+            "column": 6
+          },
+          "end": {
+            "line": 88,
+            "column": 64
+          }
+        },
+        "43": {
+          "start": {
+            "line": 92,
+            "column": 4
+          },
+          "end": {
+            "line": 94,
+            "column": 5
+          }
+        },
+        "44": {
+          "start": {
+            "line": 93,
+            "column": 6
+          },
+          "end": {
+            "line": 93,
+            "column": 60
+          }
+        },
+        "45": {
+          "start": {
+            "line": 96,
+            "column": 4
+          },
+          "end": {
+            "line": 96,
+            "column": 33
+          }
+        },
+        "46": {
+          "start": {
+            "line": 100,
+            "column": 17
+          },
+          "end": {
+            "line": 102,
+            "column": 1
+          }
+        },
+        "47": {
+          "start": {
+            "line": 101,
+            "column": 2
+          },
+          "end": {
+            "line": 101,
+            "column": 30
+          }
+        },
+        "48": {
+          "start": {
+            "line": 104,
+            "column": 0
+          },
+          "end": {
+            "line": 111,
+            "column": 1
+          }
+        },
+        "49": {
+          "start": {
+            "line": 113,
+            "column": 0
+          },
+          "end": {
+            "line": 113,
+            "column": 27
+          }
+        }
+      },
+      "fnMap": {
+        "0": {
+          "name": "TestExclude",
+          "decl": {
+            "start": {
+              "line": 12,
+              "column": 9
+            },
+            "end": {
+              "line": 12,
+              "column": 20
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 28
+            },
+            "end": {
+              "line": 45,
+              "column": 1
+            }
+          },
+          "line": 12
+        },
+        "1": {
+          "name": "(anonymous_1)",
+          "decl": {
+            "start": {
+              "line": 50,
+              "column": 51
+            },
+            "end": {
+              "line": 50,
+              "column": 52
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 50,
+              "column": 63
+            },
+            "end": {
+              "line": 59,
+              "column": 1
+            }
+          },
+          "line": 50
+        },
+        "2": {
+          "name": "(anonymous_2)",
+          "decl": {
+            "start": {
+              "line": 52,
+              "column": 37
+            },
+            "end": {
+              "line": 52,
+              "column": 38
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 52,
+              "column": 50
+            },
+            "end": {
+              "line": 57,
+              "column": 3
+            }
+          },
+          "line": 52
+        },
+        "3": {
+          "name": "(anonymous_3)",
+          "decl": {
+            "start": {
+              "line": 61,
+              "column": 41
+            },
+            "end": {
+              "line": 61,
+              "column": 42
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 61,
+              "column": 70
+            },
+            "end": {
+              "line": 69,
+              "column": 1
+            }
+          },
+          "line": 61
+        },
+        "4": {
+          "name": "(anonymous_4)",
+          "decl": {
+            "start": {
+              "line": 71,
+              "column": 32
+            },
+            "end": {
+              "line": 71,
+              "column": 33
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 71,
+              "column": 53
+            },
+            "end": {
+              "line": 82,
+              "column": 1
+            }
+          },
+          "line": 71
+        },
+        "5": {
+          "name": "prepGlobPatterns",
+          "decl": {
+            "start": {
+              "line": 84,
+              "column": 9
+            },
+            "end": {
+              "line": 84,
+              "column": 25
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 84,
+              "column": 37
+            },
+            "end": {
+              "line": 98,
+              "column": 1
+            }
+          },
+          "line": 84
+        },
+        "6": {
+          "name": "(anonymous_6)",
+          "decl": {
+            "start": {
+              "line": 85,
+              "column": 25
+            },
+            "end": {
+              "line": 85,
+              "column": 26
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 85,
+              "column": 52
+            },
+            "end": {
+              "line": 97,
+              "column": 3
+            }
+          },
+          "line": 85
+        },
+        "7": {
+          "name": "(anonymous_7)",
+          "decl": {
+            "start": {
+              "line": 100,
+              "column": 17
+            },
+            "end": {
+              "line": 100,
+              "column": 18
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 100,
+              "column": 33
+            },
+            "end": {
+              "line": 102,
+              "column": 1
+            }
+          },
+          "line": 100
+        }
+      },
+      "branchMap": {
+        "0": {
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 2
+            },
+            "end": {
+              "line": 21,
+              "column": 81
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            },
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            }
+          ],
+          "line": 21
+        },
+        "1": {
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 55
+            },
+            "end": {
+              "line": 21,
+              "column": 81
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 21,
+                "column": 55
+              },
+              "end": {
+                "line": 21,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 21,
+                "column": 73
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            }
+          ],
+          "line": 21
+        },
+        "2": {
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 2
+            },
+            "end": {
+              "line": 22,
+              "column": 69
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            }
+          ],
+          "line": 22
+        },
+        "3": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 2
+            },
+            "end": {
+              "line": 26,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            }
+          ],
+          "line": 24
+        },
+        "4": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 6
+            },
+            "end": {
+              "line": 24,
+              "column": 54
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 6
+              },
+              "end": {
+                "line": 24,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 23
+              },
+              "end": {
+                "line": 24,
+                "column": 36
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 40
+              },
+              "end": {
+                "line": 24,
+                "column": 54
+              }
+            }
+          ],
+          "line": 24
+        },
+        "5": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 30,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            }
+          ],
+          "line": 28
+        },
+        "6": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 6
+            },
+            "end": {
+              "line": 28,
+              "column": 51
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 6
+              },
+              "end": {
+                "line": 28,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 23
+              },
+              "end": {
+                "line": 28,
+                "column": 51
+              }
+            }
+          ],
+          "line": 28
+        },
+        "7": {
+          "loc": {
+            "start": {
+              "line": 29,
+              "column": 19
+            },
+            "end": {
+              "line": 29,
+              "column": 54
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 29,
+                "column": 19
+              },
+              "end": {
+                "line": 29,
+                "column": 44
+              }
+            },
+            {
+              "start": {
+                "line": 29,
+                "column": 48
+              },
+              "end": {
+                "line": 29,
+                "column": 54
+              }
+            }
+          ],
+          "line": 29
+        },
+        "8": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 2
+            },
+            "end": {
+              "line": 36,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            }
+          ],
+          "line": 32
+        },
+        "9": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 6
+            },
+            "end": {
+              "line": 32,
+              "column": 45
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 6
+              },
+              "end": {
+                "line": 32,
+                "column": 18
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 22
+              },
+              "end": {
+                "line": 32,
+                "column": 45
+              }
+            }
+          ],
+          "line": 32
+        },
+        "10": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 2
+            },
+            "end": {
+              "line": 40,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            }
+          ],
+          "line": 38
+        },
+        "11": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 6
+            },
+            "end": {
+              "line": 38,
+              "column": 93
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 6
+              },
+              "end": {
+                "line": 38,
+                "column": 40
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 44
+              },
+              "end": {
+                "line": 38,
+                "column": 93
+              }
+            }
+          ],
+          "line": 38
+        },
+        "12": {
+          "loc": {
+            "start": {
+              "line": 55,
+              "column": 4
+            },
+            "end": {
+              "line": 55,
+              "column": 44
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            },
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            }
+          ],
+          "line": 55
+        },
+        "13": {
+          "loc": {
+            "start": {
+              "line": 62,
+              "column": 12
+            },
+            "end": {
+              "line": 62,
+              "column": 56
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 62,
+                "column": 12
+              },
+              "end": {
+                "line": 62,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 62,
+                "column": 23
+              },
+              "end": {
+                "line": 62,
+                "column": 56
+              }
+            }
+          ],
+          "line": 62
+        },
+        "14": {
+          "loc": {
+            "start": {
+              "line": 65,
+              "column": 2
+            },
+            "end": {
+              "line": 65,
+              "column": 67
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            },
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            }
+          ],
+          "line": 65
+        },
+        "15": {
+          "loc": {
+            "start": {
+              "line": 68,
+              "column": 9
+            },
+            "end": {
+              "line": 68,
+              "column": 143
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 68,
+                "column": 10
+              },
+              "end": {
+                "line": 68,
+                "column": 23
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 27
+              },
+              "end": {
+                "line": 68,
+                "column": 82
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 87
+              },
+              "end": {
+                "line": 68,
+                "column": 143
+              }
+            }
+          ],
+          "line": 68
+        },
+        "16": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            }
+          ],
+          "line": 76
+        },
+        "17": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 6
+            },
+            "end": {
+              "line": 76,
+              "column": 65
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 6
+              },
+              "end": {
+                "line": 76,
+                "column": 13
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 17
+              },
+              "end": {
+                "line": 76,
+                "column": 29
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 33
+              },
+              "end": {
+                "line": 76,
+                "column": 65
+              }
+            }
+          ],
+          "line": 76
+        },
+        "18": {
+          "loc": {
+            "start": {
+              "line": 87,
+              "column": 4
+            },
+            "end": {
+              "line": 89,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            }
+          ],
+          "line": 87
+        },
+        "19": {
+          "loc": {
+            "start": {
+              "line": 92,
+              "column": 4
+            },
+            "end": {
+              "line": 94,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            }
+          ],
+          "line": 92
+        }
+      },
+      "s": {
+        "0": 1,
+        "1": 1,
+        "2": 1,
+        "3": 1,
+        "4": 1,
+        "5": 21,
+        "6": 21,
+        "7": 1,
+        "8": 21,
+        "9": 1,
+        "10": 21,
+        "11": 7,
+        "12": 21,
+        "13": 15,
+        "14": 21,
+        "15": 5,
+        "16": 16,
+        "17": 21,
+        "18": 5,
+        "19": 21,
+        "20": 1,
+        "21": 21,
+        "22": 21,
+        "23": 95,
+        "24": 95,
+        "25": 1,
+        "26": 95,
+        "27": 21,
+        "28": 1,
+        "29": 56,
+        "30": 56,
+        "31": 1,
+        "32": 55,
+        "33": 55,
+        "34": 1,
+        "35": 7,
+        "36": 7,
+        "37": 6,
+        "38": 6,
+        "39": 1,
+        "40": 26,
+        "41": 105,
+        "42": 39,
+        "43": 105,
+        "44": 50,
+        "45": 105,
+        "46": 1,
+        "47": 21,
+        "48": 1,
+        "49": 1
+      },
+      "f": {
+        "0": 21,
+        "1": 21,
+        "2": 95,
+        "3": 56,
+        "4": 7,
+        "5": 26,
+        "6": 105,
+        "7": 21
+      },
+      "b": {
+        "0": [
+          1,
+          20
+        ],
+        "1": [
+          1,
+          0
+        ],
+        "2": [
+          1,
+          20
+        ],
+        "3": [
+          7,
+          14
+        ],
+        "4": [
+          21,
+          18,
+          15
+        ],
+        "5": [
+          15,
+          6
+        ],
+        "6": [
+          21,
+          8
+        ],
+        "7": [
+          15,
+          0
+        ],
+        "8": [
+          5,
+          16
+        ],
+        "9": [
+          21,
+          5
+        ],
+        "10": [
+          5,
+          16
+        ],
+        "11": [
+          21,
+          20
+        ],
+        "12": [
+          1,
+          94
+        ],
+        "13": [
+          56,
+          56
+        ],
+        "14": [
+          1,
+          55
+        ],
+        "15": [
+          55,
+          15,
+          50
+        ],
+        "16": [
+          6,
+          1
+        ],
+        "17": [
+          7,
+          7,
+          6
+        ],
+        "18": [
+          39,
+          66
+        ],
+        "19": [
+          50,
+          55
+        ]
+      },
+      "_coverageSchema": "332fd63041d2c1bcb487cc26dd0d5f7d97098a6c",
+      "hash": "f56f8d0db960f08dcdda97d0882cfd589e74eae5",
+      "contentHash": "4437193939a265a773fe2ec1a2d065a3_10.2.0"
+    }
+  }
+}

--- a/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
@@ -1,0 +1,1643 @@
+{
+  "title": "missing line and branch coverage",
+  "textReportExpected": "----------|----------|----------|----------|----------|----------------|\nFile      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |\n----------|----------|----------|----------|----------|----------------|\n\u001b[32;1mAll files\u001b[0m |\u001b[32;1m    98.04\u001b[0m |\u001b[32;1m    95.35\u001b[0m |\u001b[32;1m    88.89\u001b[0m |\u001b[32;1m    97.87\u001b[0m |\u001b[31;1m               \u001b[0m |\n\u001b[32;1m index.js\u001b[0m |\u001b[32;1m    98.04\u001b[0m |\u001b[32;1m    95.35\u001b[0m |\u001b[32;1m    88.89\u001b[0m |\u001b[32;1m    97.87\u001b[0m |\u001b[31;1m              9\u001b[0m |\n----------|----------|----------|----------|----------|----------------|\n",
+  "map": {
+    "/Users/benjamincoe/oss/test-exclude/index.js": {
+      "path": "/Users/benjamincoe/oss/test-exclude/index.js",
+      "statementMap": {
+        "0": {
+          "start": {
+            "line": 1,
+            "column": 15
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        },
+        "1": {
+          "start": {
+            "line": 2,
+            "column": 15
+          },
+          "end": {
+            "line": 2,
+            "column": 32
+          }
+        },
+        "2": {
+          "start": {
+            "line": 3,
+            "column": 19
+          },
+          "end": {
+            "line": 3,
+            "column": 40
+          }
+        },
+        "3": {
+          "start": {
+            "line": 4,
+            "column": 13
+          },
+          "end": {
+            "line": 4,
+            "column": 28
+          }
+        },
+        "4": {
+          "start": {
+            "line": 5,
+            "column": 18
+          },
+          "end": {
+            "line": 5,
+            "column": 40
+          }
+        },
+        "5": {
+          "start": {
+            "line": 9,
+            "column": 2
+          },
+          "end": {
+            "line": 9,
+            "column": 11
+          }
+        },
+        "6": {
+          "start": {
+            "line": 13,
+            "column": 2
+          },
+          "end": {
+            "line": 19,
+            "column": 10
+          }
+        },
+        "7": {
+          "start": {
+            "line": 21,
+            "column": 2
+          },
+          "end": {
+            "line": 21,
+            "column": 81
+          }
+        },
+        "8": {
+          "start": {
+            "line": 21,
+            "column": 40
+          },
+          "end": {
+            "line": 21,
+            "column": 81
+          }
+        },
+        "9": {
+          "start": {
+            "line": 22,
+            "column": 2
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "10": {
+          "start": {
+            "line": 22,
+            "column": 40
+          },
+          "end": {
+            "line": 22,
+            "column": 69
+          }
+        },
+        "11": {
+          "start": {
+            "line": 24,
+            "column": 2
+          },
+          "end": {
+            "line": 26,
+            "column": 3
+          }
+        },
+        "12": {
+          "start": {
+            "line": 25,
+            "column": 4
+          },
+          "end": {
+            "line": 25,
+            "column": 63
+          }
+        },
+        "13": {
+          "start": {
+            "line": 28,
+            "column": 2
+          },
+          "end": {
+            "line": 30,
+            "column": 3
+          }
+        },
+        "14": {
+          "start": {
+            "line": 29,
+            "column": 4
+          },
+          "end": {
+            "line": 29,
+            "column": 54
+          }
+        },
+        "15": {
+          "start": {
+            "line": 32,
+            "column": 2
+          },
+          "end": {
+            "line": 36,
+            "column": 3
+          }
+        },
+        "16": {
+          "start": {
+            "line": 33,
+            "column": 4
+          },
+          "end": {
+            "line": 33,
+            "column": 57
+          }
+        },
+        "17": {
+          "start": {
+            "line": 35,
+            "column": 4
+          },
+          "end": {
+            "line": 35,
+            "column": 24
+          }
+        },
+        "18": {
+          "start": {
+            "line": 38,
+            "column": 2
+          },
+          "end": {
+            "line": 40,
+            "column": 3
+          }
+        },
+        "19": {
+          "start": {
+            "line": 39,
+            "column": 4
+          },
+          "end": {
+            "line": 39,
+            "column": 43
+          }
+        },
+        "20": {
+          "start": {
+            "line": 42,
+            "column": 2
+          },
+          "end": {
+            "line": 44,
+            "column": 3
+          }
+        },
+        "21": {
+          "start": {
+            "line": 50,
+            "column": 0
+          },
+          "end": {
+            "line": 59,
+            "column": 1
+          }
+        },
+        "22": {
+          "start": {
+            "line": 51,
+            "column": 29
+          },
+          "end": {
+            "line": 51,
+            "column": 34
+          }
+        },
+        "23": {
+          "start": {
+            "line": 52,
+            "column": 2
+          },
+          "end": {
+            "line": 57,
+            "column": 4
+          }
+        },
+        "24": {
+          "start": {
+            "line": 53,
+            "column": 18
+          },
+          "end": {
+            "line": 54,
+            "column": 71
+          }
+        },
+        "25": {
+          "start": {
+            "line": 55,
+            "column": 4
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "26": {
+          "start": {
+            "line": 55,
+            "column": 17
+          },
+          "end": {
+            "line": 55,
+            "column": 44
+          }
+        },
+        "27": {
+          "start": {
+            "line": 56,
+            "column": 4
+          },
+          "end": {
+            "line": 56,
+            "column": 19
+          }
+        },
+        "28": {
+          "start": {
+            "line": 58,
+            "column": 2
+          },
+          "end": {
+            "line": 58,
+            "column": 29
+          }
+        },
+        "29": {
+          "start": {
+            "line": 61,
+            "column": 0
+          },
+          "end": {
+            "line": 69,
+            "column": 1
+          }
+        },
+        "30": {
+          "start": {
+            "line": 62,
+            "column": 2
+          },
+          "end": {
+            "line": 62,
+            "column": 56
+          }
+        },
+        "31": {
+          "start": {
+            "line": 65,
+            "column": 2
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "32": {
+          "start": {
+            "line": 65,
+            "column": 55
+          },
+          "end": {
+            "line": 65,
+            "column": 67
+          }
+        },
+        "33": {
+          "start": {
+            "line": 67,
+            "column": 2
+          },
+          "end": {
+            "line": 67,
+            "column": 43
+          }
+        },
+        "34": {
+          "start": {
+            "line": 68,
+            "column": 2
+          },
+          "end": {
+            "line": 68,
+            "column": 143
+          }
+        },
+        "35": {
+          "start": {
+            "line": 71,
+            "column": 0
+          },
+          "end": {
+            "line": 82,
+            "column": 1
+          }
+        },
+        "36": {
+          "start": {
+            "line": 72,
+            "column": 14
+          },
+          "end": {
+            "line": 74,
+            "column": 4
+          }
+        },
+        "37": {
+          "start": {
+            "line": 76,
+            "column": 2
+          },
+          "end": {
+            "line": 81,
+            "column": 3
+          }
+        },
+        "38": {
+          "start": {
+            "line": 77,
+            "column": 4
+          },
+          "end": {
+            "line": 77,
+            "column": 27
+          }
+        },
+        "39": {
+          "start": {
+            "line": 78,
+            "column": 4
+          },
+          "end": {
+            "line": 78,
+            "column": 23
+          }
+        },
+        "40": {
+          "start": {
+            "line": 80,
+            "column": 4
+          },
+          "end": {
+            "line": 80,
+            "column": 13
+          }
+        },
+        "41": {
+          "start": {
+            "line": 85,
+            "column": 2
+          },
+          "end": {
+            "line": 97,
+            "column": 8
+          }
+        },
+        "42": {
+          "start": {
+            "line": 87,
+            "column": 4
+          },
+          "end": {
+            "line": 89,
+            "column": 5
+          }
+        },
+        "43": {
+          "start": {
+            "line": 88,
+            "column": 6
+          },
+          "end": {
+            "line": 88,
+            "column": 64
+          }
+        },
+        "44": {
+          "start": {
+            "line": 92,
+            "column": 4
+          },
+          "end": {
+            "line": 94,
+            "column": 5
+          }
+        },
+        "45": {
+          "start": {
+            "line": 93,
+            "column": 6
+          },
+          "end": {
+            "line": 93,
+            "column": 60
+          }
+        },
+        "46": {
+          "start": {
+            "line": 96,
+            "column": 4
+          },
+          "end": {
+            "line": 96,
+            "column": 33
+          }
+        },
+        "47": {
+          "start": {
+            "line": 100,
+            "column": 17
+          },
+          "end": {
+            "line": 102,
+            "column": 1
+          }
+        },
+        "48": {
+          "start": {
+            "line": 101,
+            "column": 2
+          },
+          "end": {
+            "line": 101,
+            "column": 30
+          }
+        },
+        "49": {
+          "start": {
+            "line": 104,
+            "column": 0
+          },
+          "end": {
+            "line": 111,
+            "column": 1
+          }
+        },
+        "50": {
+          "start": {
+            "line": 113,
+            "column": 0
+          },
+          "end": {
+            "line": 113,
+            "column": 27
+          }
+        }
+      },
+      "fnMap": {
+        "0": {
+          "name": "foo",
+          "decl": {
+            "start": {
+              "line": 8,
+              "column": 9
+            },
+            "end": {
+              "line": 8,
+              "column": 12
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 16
+            },
+            "end": {
+              "line": 10,
+              "column": 1
+            }
+          },
+          "line": 8
+        },
+        "1": {
+          "name": "TestExclude",
+          "decl": {
+            "start": {
+              "line": 12,
+              "column": 9
+            },
+            "end": {
+              "line": 12,
+              "column": 20
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 28
+            },
+            "end": {
+              "line": 45,
+              "column": 1
+            }
+          },
+          "line": 12
+        },
+        "2": {
+          "name": "(anonymous_2)",
+          "decl": {
+            "start": {
+              "line": 50,
+              "column": 51
+            },
+            "end": {
+              "line": 50,
+              "column": 52
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 50,
+              "column": 63
+            },
+            "end": {
+              "line": 59,
+              "column": 1
+            }
+          },
+          "line": 50
+        },
+        "3": {
+          "name": "(anonymous_3)",
+          "decl": {
+            "start": {
+              "line": 52,
+              "column": 37
+            },
+            "end": {
+              "line": 52,
+              "column": 38
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 52,
+              "column": 50
+            },
+            "end": {
+              "line": 57,
+              "column": 3
+            }
+          },
+          "line": 52
+        },
+        "4": {
+          "name": "(anonymous_4)",
+          "decl": {
+            "start": {
+              "line": 61,
+              "column": 41
+            },
+            "end": {
+              "line": 61,
+              "column": 42
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 61,
+              "column": 70
+            },
+            "end": {
+              "line": 69,
+              "column": 1
+            }
+          },
+          "line": 61
+        },
+        "5": {
+          "name": "(anonymous_5)",
+          "decl": {
+            "start": {
+              "line": 71,
+              "column": 32
+            },
+            "end": {
+              "line": 71,
+              "column": 33
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 71,
+              "column": 53
+            },
+            "end": {
+              "line": 82,
+              "column": 1
+            }
+          },
+          "line": 71
+        },
+        "6": {
+          "name": "prepGlobPatterns",
+          "decl": {
+            "start": {
+              "line": 84,
+              "column": 9
+            },
+            "end": {
+              "line": 84,
+              "column": 25
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 84,
+              "column": 37
+            },
+            "end": {
+              "line": 98,
+              "column": 1
+            }
+          },
+          "line": 84
+        },
+        "7": {
+          "name": "(anonymous_7)",
+          "decl": {
+            "start": {
+              "line": 85,
+              "column": 25
+            },
+            "end": {
+              "line": 85,
+              "column": 26
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 85,
+              "column": 52
+            },
+            "end": {
+              "line": 97,
+              "column": 3
+            }
+          },
+          "line": 85
+        },
+        "8": {
+          "name": "(anonymous_8)",
+          "decl": {
+            "start": {
+              "line": 100,
+              "column": 17
+            },
+            "end": {
+              "line": 100,
+              "column": 18
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 100,
+              "column": 33
+            },
+            "end": {
+              "line": 102,
+              "column": 1
+            }
+          },
+          "line": 100
+        }
+      },
+      "branchMap": {
+        "0": {
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 2
+            },
+            "end": {
+              "line": 21,
+              "column": 81
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            },
+            {
+              "start": {
+                "line": 21,
+                "column": 2
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            }
+          ],
+          "line": 21
+        },
+        "1": {
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 55
+            },
+            "end": {
+              "line": 21,
+              "column": 81
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 21,
+                "column": 55
+              },
+              "end": {
+                "line": 21,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 21,
+                "column": 73
+              },
+              "end": {
+                "line": 21,
+                "column": 81
+              }
+            }
+          ],
+          "line": 21
+        },
+        "2": {
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 2
+            },
+            "end": {
+              "line": 22,
+              "column": 69
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            },
+            {
+              "start": {
+                "line": 22,
+                "column": 2
+              },
+              "end": {
+                "line": 22,
+                "column": 69
+              }
+            }
+          ],
+          "line": 22
+        },
+        "3": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 2
+            },
+            "end": {
+              "line": 26,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            }
+          ],
+          "line": 24
+        },
+        "4": {
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 6
+            },
+            "end": {
+              "line": 24,
+              "column": 54
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 24,
+                "column": 6
+              },
+              "end": {
+                "line": 24,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 23
+              },
+              "end": {
+                "line": 24,
+                "column": 36
+              }
+            },
+            {
+              "start": {
+                "line": 24,
+                "column": 40
+              },
+              "end": {
+                "line": 24,
+                "column": 54
+              }
+            }
+          ],
+          "line": 24
+        },
+        "5": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 30,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 2
+              },
+              "end": {
+                "line": 30,
+                "column": 3
+              }
+            }
+          ],
+          "line": 28
+        },
+        "6": {
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 6
+            },
+            "end": {
+              "line": 28,
+              "column": 51
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 28,
+                "column": 6
+              },
+              "end": {
+                "line": 28,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 28,
+                "column": 23
+              },
+              "end": {
+                "line": 28,
+                "column": 51
+              }
+            }
+          ],
+          "line": 28
+        },
+        "7": {
+          "loc": {
+            "start": {
+              "line": 29,
+              "column": 19
+            },
+            "end": {
+              "line": 29,
+              "column": 54
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 29,
+                "column": 19
+              },
+              "end": {
+                "line": 29,
+                "column": 44
+              }
+            },
+            {
+              "start": {
+                "line": 29,
+                "column": 48
+              },
+              "end": {
+                "line": 29,
+                "column": 54
+              }
+            }
+          ],
+          "line": 29
+        },
+        "8": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 2
+            },
+            "end": {
+              "line": 36,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 2
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            }
+          ],
+          "line": 32
+        },
+        "9": {
+          "loc": {
+            "start": {
+              "line": 32,
+              "column": 6
+            },
+            "end": {
+              "line": 32,
+              "column": 45
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 32,
+                "column": 6
+              },
+              "end": {
+                "line": 32,
+                "column": 18
+              }
+            },
+            {
+              "start": {
+                "line": 32,
+                "column": 22
+              },
+              "end": {
+                "line": 32,
+                "column": 45
+              }
+            }
+          ],
+          "line": 32
+        },
+        "10": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 2
+            },
+            "end": {
+              "line": 40,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 2
+              },
+              "end": {
+                "line": 40,
+                "column": 3
+              }
+            }
+          ],
+          "line": 38
+        },
+        "11": {
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 6
+            },
+            "end": {
+              "line": 38,
+              "column": 93
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 38,
+                "column": 6
+              },
+              "end": {
+                "line": 38,
+                "column": 40
+              }
+            },
+            {
+              "start": {
+                "line": 38,
+                "column": 44
+              },
+              "end": {
+                "line": 38,
+                "column": 93
+              }
+            }
+          ],
+          "line": 38
+        },
+        "12": {
+          "loc": {
+            "start": {
+              "line": 55,
+              "column": 4
+            },
+            "end": {
+              "line": 55,
+              "column": 44
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            },
+            {
+              "start": {
+                "line": 55,
+                "column": 4
+              },
+              "end": {
+                "line": 55,
+                "column": 44
+              }
+            }
+          ],
+          "line": 55
+        },
+        "13": {
+          "loc": {
+            "start": {
+              "line": 62,
+              "column": 12
+            },
+            "end": {
+              "line": 62,
+              "column": 56
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 62,
+                "column": 12
+              },
+              "end": {
+                "line": 62,
+                "column": 19
+              }
+            },
+            {
+              "start": {
+                "line": 62,
+                "column": 23
+              },
+              "end": {
+                "line": 62,
+                "column": 56
+              }
+            }
+          ],
+          "line": 62
+        },
+        "14": {
+          "loc": {
+            "start": {
+              "line": 65,
+              "column": 2
+            },
+            "end": {
+              "line": 65,
+              "column": 67
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            },
+            {
+              "start": {
+                "line": 65,
+                "column": 2
+              },
+              "end": {
+                "line": 65,
+                "column": 67
+              }
+            }
+          ],
+          "line": 65
+        },
+        "15": {
+          "loc": {
+            "start": {
+              "line": 68,
+              "column": 9
+            },
+            "end": {
+              "line": 68,
+              "column": 143
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 68,
+                "column": 10
+              },
+              "end": {
+                "line": 68,
+                "column": 23
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 27
+              },
+              "end": {
+                "line": 68,
+                "column": 82
+              }
+            },
+            {
+              "start": {
+                "line": 68,
+                "column": 87
+              },
+              "end": {
+                "line": 68,
+                "column": 143
+              }
+            }
+          ],
+          "line": 68
+        },
+        "16": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 2
+              },
+              "end": {
+                "line": 81,
+                "column": 3
+              }
+            }
+          ],
+          "line": 76
+        },
+        "17": {
+          "loc": {
+            "start": {
+              "line": 76,
+              "column": 6
+            },
+            "end": {
+              "line": 76,
+              "column": 65
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 76,
+                "column": 6
+              },
+              "end": {
+                "line": 76,
+                "column": 13
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 17
+              },
+              "end": {
+                "line": 76,
+                "column": 29
+              }
+            },
+            {
+              "start": {
+                "line": 76,
+                "column": 33
+              },
+              "end": {
+                "line": 76,
+                "column": 65
+              }
+            }
+          ],
+          "line": 76
+        },
+        "18": {
+          "loc": {
+            "start": {
+              "line": 87,
+              "column": 4
+            },
+            "end": {
+              "line": 89,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 87,
+                "column": 4
+              },
+              "end": {
+                "line": 89,
+                "column": 5
+              }
+            }
+          ],
+          "line": 87
+        },
+        "19": {
+          "loc": {
+            "start": {
+              "line": 92,
+              "column": 4
+            },
+            "end": {
+              "line": 94,
+              "column": 5
+            }
+          },
+          "type": "if",
+          "locations": [
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            },
+            {
+              "start": {
+                "line": 92,
+                "column": 4
+              },
+              "end": {
+                "line": 94,
+                "column": 5
+              }
+            }
+          ],
+          "line": 92
+        }
+      },
+      "s": {
+        "0": 1,
+        "1": 1,
+        "2": 1,
+        "3": 1,
+        "4": 1,
+        "5": 0,
+        "6": 21,
+        "7": 21,
+        "8": 1,
+        "9": 21,
+        "10": 1,
+        "11": 21,
+        "12": 7,
+        "13": 21,
+        "14": 15,
+        "15": 21,
+        "16": 5,
+        "17": 16,
+        "18": 21,
+        "19": 5,
+        "20": 21,
+        "21": 1,
+        "22": 21,
+        "23": 21,
+        "24": 95,
+        "25": 95,
+        "26": 1,
+        "27": 95,
+        "28": 21,
+        "29": 1,
+        "30": 56,
+        "31": 56,
+        "32": 1,
+        "33": 55,
+        "34": 55,
+        "35": 1,
+        "36": 7,
+        "37": 7,
+        "38": 6,
+        "39": 6,
+        "40": 1,
+        "41": 26,
+        "42": 105,
+        "43": 39,
+        "44": 105,
+        "45": 50,
+        "46": 105,
+        "47": 1,
+        "48": 21,
+        "49": 1,
+        "50": 1
+      },
+      "f": {
+        "0": 0,
+        "1": 21,
+        "2": 21,
+        "3": 95,
+        "4": 56,
+        "5": 7,
+        "6": 26,
+        "7": 105,
+        "8": 21
+      },
+      "b": {
+        "0": [
+          1,
+          20
+        ],
+        "1": [
+          1,
+          0
+        ],
+        "2": [
+          1,
+          20
+        ],
+        "3": [
+          7,
+          14
+        ],
+        "4": [
+          21,
+          18,
+          15
+        ],
+        "5": [
+          15,
+          6
+        ],
+        "6": [
+          21,
+          8
+        ],
+        "7": [
+          15,
+          0
+        ],
+        "8": [
+          5,
+          16
+        ],
+        "9": [
+          21,
+          5
+        ],
+        "10": [
+          5,
+          16
+        ],
+        "11": [
+          21,
+          20
+        ],
+        "12": [
+          1,
+          94
+        ],
+        "13": [
+          56,
+          56
+        ],
+        "14": [
+          1,
+          55
+        ],
+        "15": [
+          55,
+          15,
+          50
+        ],
+        "16": [
+          6,
+          1
+        ],
+        "17": [
+          7,
+          7,
+          6
+        ],
+        "18": [
+          39,
+          66
+        ],
+        "19": [
+          50,
+          55
+        ]
+      },
+      "_coverageSchema": "332fd63041d2c1bcb487cc26dd0d5f7d97098a6c",
+      "hash": "257c6f21b24c87c5486d0ac83455acd3e4aebb6d",
+      "contentHash": "fe9edcd7fde8f2a27202e2634386d126_10.2.0"
+    }
+  }
+}

--- a/packages/istanbul-reports/test/text/index.js
+++ b/packages/istanbul-reports/test/text/index.js
@@ -1,5 +1,6 @@
 /* globals describe, it, beforeEach, before, after */
 var fs = require('fs'),
+    isWindows = require('is-windows'),
     path = require('path'),
     FileWriter = require('istanbul-lib-report/lib/file-writer'),
     istanbulLibReport = require('istanbul-lib-report'),
@@ -23,6 +24,9 @@ describe('TextReport', function () {
       var fixture = require(path.resolve(__dirname, '../fixtures/specs/' + file));
       fixture.map = istanbulLibReport.summarizers.pkg(istanbulLibCoverage.createCoverageMap(fixture.map));
       it(fixture.title, function () {
+          if (isWindows()) { // appveyor does not render console color.
+              return this.skip();
+          }
           var context = istanbulLibReport.createContext({
             dir: './'
           });

--- a/packages/istanbul-reports/test/text/index.js
+++ b/packages/istanbul-reports/test/text/index.js
@@ -1,0 +1,42 @@
+/* globals describe, it, beforeEach, before, after */
+var fs = require('fs'),
+    path = require('path'),
+    FileWriter = require('istanbul-lib-report/lib/file-writer'),
+    istanbulLibReport = require('istanbul-lib-report'),
+    istanbulLibCoverage = require('istanbul-lib-coverage'),
+    TextReport = require('../../lib/text/index');
+
+require('chai').should();
+
+describe('TextReport', function () {
+  before(function () {
+      FileWriter.startCapture();
+  });
+  after(function () {
+      FileWriter.stopCapture();
+  });
+  beforeEach(function () {
+      FileWriter.resetOutput();
+  });
+
+  function createTest (file) {
+      var fixture = require(path.resolve(__dirname, '../fixtures/specs/' + file));
+      fixture.map = istanbulLibReport.summarizers.pkg(istanbulLibCoverage.createCoverageMap(fixture.map));
+      it(fixture.title, function () {
+          var context = istanbulLibReport.createContext({
+            dir: './'
+          });
+          var tree = fixture.map;
+          var report = new TextReport(context);
+          tree.visit(report, context);
+          var output = FileWriter.getOutput();
+          output.should.equal(fixture.textReportExpected);
+      });
+  }
+
+  fs.readdirSync(path.resolve(__dirname, '../fixtures/specs')).forEach(function (file) {
+      if (file.indexOf('.json') !== -1) {
+          createTest(file);
+      }
+  });
+});


### PR DESCRIPTION
Implement @isaacs suggestion in #41, we will now show missing branches once 100% line coverage is reached:

<img width="513" alt="screen shot 2017-04-28 at 7 16 49 pm" src="https://cloud.githubusercontent.com/assets/194609/25552164/63a2a5d4-2c47-11e7-9982-8eda2177ae96.png">

fixes #41 

