### PR TITLE
chore: update repo url

### DIFF
--- a/packages/istanbul-api/package.json
+++ b/packages/istanbul-api/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/istanbuljs/istanbul-api.git"
+    "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "istanbul",
@@ -23,9 +23,9 @@
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-api/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-api#readme",
+  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
   "devDependencies": {
     "chai": "^3.0.0",
     "is-windows": "^1.0.0",

--- a/packages/istanbul-lib-coverage/package.json
+++ b/packages/istanbul-lib-coverage/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:istanbuljs/istanbul-lib-coverage.git"
+    "url": "git@github.com:istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "istanbul",
@@ -38,7 +38,7 @@
   ],
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-lib-coverage/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-coverage"
+  "homepage": "https://github.com/istanbuljs/istanbuljs"
 }

--- a/packages/istanbul-lib-hook/package.json
+++ b/packages/istanbul-lib-hook/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/istanbuljs/istanbul-lib-hook.git"
+    "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "istanbul",
@@ -30,7 +30,7 @@
   ],
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-lib-hook/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-hook#readme"
+  "homepage": "https://github.com/istanbuljs/istanbuljs#readme"
 }

--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -39,12 +39,12 @@
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-lib-instrument/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-instrument",
+  "homepage": "https://github.com/istanbuljs/istanbuljs",
   "repository": {
     "type": "git",
-    "url": "git@github.com:istanbuljs/istanbul-lib-instrument.git"
+    "url": "git@github.com:istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "coverage",

--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -27,12 +27,12 @@
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-lib-report/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-report",
+  "homepage": "https://github.com/istanbuljs/istanbuljs",
   "repository": {
     "type": "git",
-    "url": "git@github.com:istanbuljs/istanbul-lib-report.git"
+    "url": "git@github.com:istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "istanbul",

--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -29,12 +29,12 @@
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-lib-source-maps/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-lib-source-maps#readme",
+  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/istanbuljs/istanbul-lib-source-maps.git"
+    "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "istanbul",

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -26,14 +26,14 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git@github.com:istanbuljs/istanbul-reports"
+    "url": "git@github.com:istanbuljs/istanbuljs"
   },
   "keywords": [
     "istanbul",
     "reports"
   ],
   "bugs": {
-    "url": "https://github.com/istanbuljs/istanbul-reports/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbul-reports"
+  "homepage": "https://github.com/istanbuljs/istanbuljs"
 }

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/istanbuljs/test-exclude.git"
+    "url": "git+https://github.com/istanbuljs/istanbuljs.git"
   },
   "keywords": [
     "exclude",
@@ -24,9 +24,9 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/istanbuljs/test-exclude/issues"
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/test-exclude#readme",
+  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.1.2",


### PR DESCRIPTION
All the urls should be refered to this repo that
can be easily found from npm.

Git url, bug url and homepage have been changed in package.json