### PR TITLE
fix: hoist statement counter for class variables

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -71,6 +71,12 @@ class VisitState {
         extractURL(node.trailingComments);
     }
 
+    // for these expressions the statement counter needs to be hoisted, so
+    // function name inference can be preserved
+    counterNeedsHoisting(path) {
+      return path.isFunctionExpression() || path.isArrowFunctionExpression() || path.isClassExpression();
+    }
+
     // all the generic stuff that needs to be done on enter for every node
     onEnter(path) {
         const n = path.node;
@@ -144,7 +150,7 @@ class VisitState {
             path.node.body.unshift(T.expressionStatement(increment));
         } else if (path.isStatement()) {
             path.insertBefore(T.expressionStatement(increment));
-        } else if ((path.isFunctionExpression() || path.isArrowFunctionExpression()) && T.isVariableDeclarator(path.parentPath)) {
+        } else if (this.counterNeedsHoisting(path) && T.isVariableDeclarator(path.parentPath)) {
             // make an attempt to hoist the statement counter, so that
             // function names are maintained.
             const parent = path.parentPath.parentPath;

--- a/packages/istanbul-lib-instrument/test/specs/classes.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/classes.yaml
@@ -1,0 +1,14 @@
+---
+name: class declaration assignment name (top-level)
+guard: isInferredClassNameAvailable
+code: |
+  const foo = class {}
+  var bar = class {}
+  output = foo.name + ' ' + bar.name;
+tests:
+  - name: properly sets function name
+    out: 'foo bar'
+    lines: {'1': 1, '2': 1, '3': 1}
+    functions: {}
+    statements: {'0': 1, '1': 1, '2': 1}
+    guard: isInferredClassNameAvailable

--- a/packages/istanbul-lib-instrument/test/util/guards.js
+++ b/packages/istanbul-lib-instrument/test/util/guards.js
@@ -53,3 +53,7 @@ export function isDefaultArgsAvailable() {
 export function isInferredFunctionNameAvailable() {
     return tryThis('const foo = function () {}; require("assert").equal(foo.name, "foo")');
 }
+
+export function isInferredClassNameAvailable() {
+  return tryThis('const foo = class {}; require("assert").equal(foo.name, "foo")');
+}


### PR DESCRIPTION
With `const foo = class {}`, `foo.name` should be `'foo'`. Without this commit the instrumentation causes `foo.name` to be an empty string.

Hoist the statement counter just like it's done for function and arrow expressions. Fixes #59.