### PR TITLE
fix: set excludes to options.ignore on fileset

### DIFF
--- a/packages/istanbul-api/lib/file-matcher.js
+++ b/packages/istanbul-api/lib/file-matcher.js
@@ -26,7 +26,7 @@ function filesFor(options, callback) {
     includes = includes && Array.isArray(includes) ? includes : [ '**/*.js' ];
     excludes = excludes && Array.isArray(excludes) ? excludes : [ '**/node_modules/**' ];
 
-    opts = { cwd: root, nodir: true, ignore: [] };
+    opts = { cwd: root, nodir: true, ignore: excludes };
     seq += 1;
     opts['x' + seq + new Date().getTime()] = true; //cache buster for minimatch cache bug
     fileset(includes.join(' '), excludes.join(' '), opts, function (err, files) {


### PR DESCRIPTION
It will make glob run faster.

---

- before:
  > fileset 7 files 7769ms
- after:
  > fileset 7 files 27ms