### PR TITLE
Fix/named export arrow function

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -154,7 +154,9 @@ class VisitState {
             // make an attempt to hoist the statement counter, so that
             // function names are maintained.
             const parent = path.parentPath.parentPath;
-            if (parent && (T.isProgram(parent.parentPath) || T.isBlockStatement(parent.parentPath))) {
+            if (parent && T.isExportNamedDeclaration(parent.parentPath)) {
+                parent.parentPath.insertBefore(T.expressionStatement(increment));
+            } else if (parent && (T.isProgram(parent.parentPath) || T.isBlockStatement(parent.parentPath))) {
                 parent.insertBefore(T.expressionStatement(
                     increment
                 ));

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -47,6 +47,15 @@ describe('varia', function () {
         assert.ok(code.match(/\/* hello */));
     });
 
+    it('preserves function names for named export arrow functions', function () {
+        /* https://github.com/istanbuljs/babel-plugin-istanbul/issues/125 */
+        var v = verifier.create('export const func = () => true;', { generateOnly: true }, { esModules: true }),
+            code;
+        assert.ok(!v.err);
+        code = v.getGeneratedCode();
+        assert.ok(code.match(/cov_(.+)\.s\[\d+\]\+\+;export const func=\(\)=>/));
+    });
+
     it('returns last coverage object', function (cb) {
         var instrumenter = new Instrumenter({coverageVariable: '__testing_coverage__'}),
             generated,


### PR DESCRIPTION
## Description

When a React component is defined as a *named export arrow function*, the name of it cannot be inferred correctly. (To be precise, it's **node** that cannot infer it) In jest coverage mode, it generates inconsistent result compared with the stored snapshots, which are usually generated without  the`--coverage` flag.

## This PR

* addes a failing test case in `test/varia.test.js` (*not sure if it's a good place though*)
* modifies the `insertCounter` function in `src/visitor.js`as follows:

```diff
-            if (parent && (T.isProgram(parent.parentPath) || T.isBlockStatement(parent.parentPath))) {
+            if (parent && T.isExportNamedDeclaration(parent.parentPath)) {
+                parent.parentPath.insertBefore(T.expressionStatement(increment));
+            } else if (parent && (T.isProgram(parent.parentPath) || T.isBlockStatement(parent.parentPath))) {
```
which fixes the failing test case.

## Issues

https://github.com/istanbuljs/babel-plugin-istanbul/issues/125