### PR TITLE
fix: branch highlighting was going to end of file for HTML reports

### DIFF
--- a/packages/istanbul-reports/lib/html/annotator.js
+++ b/packages/istanbul-reports/lib/html/annotator.js
@@ -57,13 +57,12 @@ function annotateStatements(fileCoverage, structuredText) {
 
         if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
-                endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
             }
             text = structuredText[startLine].text;
             text.wrap(startCol,
                 openSpan,
-                startLine === endLine ? endCol : text.originalLength(),
+                startCol < endCol ? endCol : text.originalLength(),
                 closeSpan);
         }
     });
@@ -90,13 +89,12 @@ function annotateFunctions(fileCoverage, structuredText) {
 
         if (type === 'no' && structuredText[startLine]) {
             if (endLine !== startLine) {
-                endLine = startLine;
                 endCol = structuredText[startLine].text.originalLength();
             }
             text = structuredText[startLine].text;
             text.wrap(startCol,
                 openSpan,
-                startLine === endLine ? endCol : text.originalLength(),
+                startCol < endCol ? endCol : text.originalLength(),
                 closeSpan);
         }
     });
@@ -145,7 +143,6 @@ function annotateBranches(fileCoverage, structuredText) {
 
                 if (count === 0 && structuredText[startLine]) { //skip branches taken
                     if (endLine !== startLine) {
-                        endLine = startLine;
                         endCol = structuredText[startLine].text.originalLength();
                     }
                     text = structuredText[startLine].text;
@@ -159,7 +156,7 @@ function annotateBranches(fileCoverage, structuredText) {
                     } else {
                         text.wrap(startCol,
                             openSpan,
-                            startLine === endLine ? endCol : text.originalLength(),
+                            startCol < endCol ? endCol : text.originalLength(),
                             closeSpan);
                     }
                 }

--- a/packages/istanbul-reports/test/fixtures/github-80a.json
+++ b/packages/istanbul-reports/test/fixtures/github-80a.json
@@ -1,0 +1,25 @@
+{
+  "statementMap": {
+    "0": {
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 0
+      }
+    }
+  },
+  "fnMap": {
+  },
+  "branchMap": {
+  },
+  "s": {
+    "0": 0
+  },
+  "f": {
+  },
+  "b": {
+  }
+}

--- a/packages/istanbul-reports/test/fixtures/github-80b.json
+++ b/packages/istanbul-reports/test/fixtures/github-80b.json
@@ -1,0 +1,38 @@
+{
+  "statementMap": {
+  },
+  "fnMap": {
+    "0": {
+      "name": "test",
+      "decl": {
+        "start": {
+          "line": 1,
+          "column": 2
+        },
+        "end": {
+          "line": 1,
+          "column": 0
+        }
+      },
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      }
+    }
+  },
+  "branchMap": {
+  },
+  "s": {
+  },
+  "f": {
+    "0": 0
+  },
+  "b": {
+  }
+}

--- a/packages/istanbul-reports/test/fixtures/github-80c.json
+++ b/packages/istanbul-reports/test/fixtures/github-80c.json
@@ -1,0 +1,42 @@
+{
+  "statementMap": {
+  },
+  "fnMap": {
+  },
+  "branchMap": {
+    "0": {
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      },
+      "type": "default-arg",
+      "locations": [
+        {
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 0
+          }
+        }
+      ]
+    }
+  },
+  "s": {
+  },
+  "f": {
+  },
+  "b": {
+    "0": [
+      0
+    ]
+  }
+}

--- a/packages/istanbul-reports/test/html/annotator.js
+++ b/packages/istanbul-reports/test/html/annotator.js
@@ -32,5 +32,38 @@ describe('annotator', function () {
       });
       annotated.annotatedCode[0].should.not.match(/Cannot read property/);
     });
+
+    // see: https://github.com/istanbuljs/istanbuljs/pull/80
+    it('handles statement meta information with end column less than start column', function () {
+      var annotated = annotator.annotateSourceCode(getFixture('github-80a'), {
+        getSource: function () {
+          return '  var test = "test";';
+        }
+      });
+      annotated.annotatedCode[0].should
+        .equal('<span class="cstat-no" title="statement not covered" >  var test = "test";</span>');
+    });
+
+    // see: https://github.com/istanbuljs/istanbuljs/pull/80
+    it('handles function meta information with end column less than start column', function () {
+      var annotated = annotator.annotateSourceCode(getFixture('github-80b'), {
+        getSource: function () {
+          return '  function test () {};';
+        }
+      });
+      annotated.annotatedCode[0].should
+        .equal('<span class="fstat-no" title="function not covered" >  function test () {};</span>');
+    });
+
+    // see: https://github.com/istanbuljs/istanbuljs/pull/80
+    it('handles branch meta information with end column less than start column', function () {
+      var annotated = annotator.annotateSourceCode(getFixture('github-80c'), {
+        getSource: function () {
+          return 'if (cond1 && cond2) {';
+        }
+      });
+      annotated.annotatedCode[0].should
+        .equal('if (cond1 &amp;&amp; <span class="branch-0 cbranch-no" title="branch not covered" >cond2) {</span>');
+    });
   });
 });


### PR DESCRIPTION
With the logic in place, seems like `startLine` will always == `endLine`
so the condition will never be `false`. Coupled with the fact that
the original `endCol` from the `meta` object seems wrong (always less
than `startCol`), the hightlighting just went to the end of the file.

~~Fix this by removing the redundant logic and always setting the
`endCol` to the end of line using `text.originalLength()`~~

Fix this by removing the redundant logic and setting the
`endCol` to the end of line using `text.originalLength()` when
the given `endCol` is less than `startCol`