### PR TITLE
Fix hook runInThisContext

### DIFF
--- a/packages/istanbul-api/lib/run-cover.js
+++ b/packages/istanbul-api/lib/run-cover.js
@@ -3,198 +3,197 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 var path = require('path'),
-    fs = require('fs'),
-    mkdirp = require('mkdirp'),
-    matcherFor = require('./file-matcher').matcherFor,
-    libInstrument = require('istanbul-lib-instrument'),
-    libCoverage = require('istanbul-lib-coverage'),
-    libSourceMaps = require('istanbul-lib-source-maps'),
-    hook = require('istanbul-lib-hook'),
-    Reporter = require('./reporter');
+  fs = require('fs'),
+  mkdirp = require('mkdirp'),
+  matcherFor = require('./file-matcher').matcherFor,
+  libInstrument = require('istanbul-lib-instrument'),
+  libCoverage = require('istanbul-lib-coverage'),
+  libSourceMaps = require('istanbul-lib-source-maps'),
+  hook = require('istanbul-lib-hook'),
+  Reporter = require('./reporter');
 
 function getCoverFunctions(config, includes, callback) {
 
-    if (!callback && typeof includes === 'function') {
-        callback = includes;
-        includes = null;
+  if (!callback && typeof includes === 'function') {
+    callback = includes;
+    includes = null;
+  }
+
+  var includePid = config.instrumentation.includePid(),
+    reportingDir = path.resolve(config.reporting.dir()),
+    reporter = new Reporter(config),
+    excludes = config.instrumentation.excludes(true),
+    coverageVar = '$$cov_' + new Date().getTime() + '$$',
+    instOpts = config.instrumentation.getInstrumenterOpts(),
+    sourceMapStore = libSourceMaps.createSourceMapStore({}),
+    instrumenter,
+    runInThisContextTransformer,
+    fakeRequire,
+    requireTransformer,
+    reportInitFn,
+    hookFn,
+    unhookFn,
+    coverageFinderFn,
+    coverageSetterFn,
+    beforeReportFn,
+    exitFn;
+
+  instOpts.coverageVariable = coverageVar;
+  instOpts.sourceMapUrlCallback = function (file, url) {
+    sourceMapStore.registerURL(file, url);
+  };
+  coverageFinderFn = function () {
+    return global[coverageVar];
+  };
+  instrumenter = libInstrument.createInstrumenter(instOpts);
+  runInThisContextTransformer = function (code, options) {
+    return instrumenter.instrumentSync(code, options.filename);
+  };
+  requireTransformer = function (code, options) {
+    var cov,
+      ret = instrumenter.instrumentSync(code, options.filename);
+    if (fakeRequire) {
+      cov = coverageFinderFn();
+      cov[options.filename] = instrumenter.lastFileCoverage();
+      return 'function x() {}';
+    }
+    return ret;
+  };
+
+  coverageSetterFn = function (cov) {
+    global[coverageVar] = cov;
+  };
+
+  reportInitFn = function () {
+    // set up reporter
+    mkdirp.sync(reportingDir); //ensure we fail early if we cannot do this
+    reporter.addAll(config.reporting.reports());
+    if (config.reporting.print() !== 'none') {
+      switch (config.reporting.print()) {
+        case 'detail':
+          reporter.add('text');
+          break;
+        case 'both':
+          reporter.add('text');
+          reporter.add('text-summary');
+          break;
+        default:
+          reporter.add('text-summary');
+          break;
+      }
+    }
+  };
+
+  var disabler;
+  hookFn = function (matchFn) {
+    var hookOpts = {
+      verbose: config.verbose,
+      extensions: config.instrumentation.extensions()
+    };
+
+    //initialize the global variable
+    coverageSetterFn({});
+    reportInitFn();
+
+    if (config.hooks.hookRunInContext()) {
+      hook.hookRunInThisContext(matchFn, runInThisContextTransformer, hookOpts);
+    } else {
+      disabler = hook.hookRequire(matchFn, requireTransformer, hookOpts);
+    }
+  };
+
+  unhookFn = function (matchFn) {
+    if (disabler) {
+      disabler();
+    }
+    hook.unhookRunInThisContext();
+    hook.unloadRequireCache(matchFn);
+  };
+
+  beforeReportFn = function (matchFn, cov) {
+    var pidExt = includePid ? ('-' + process.pid) : '',
+      file = path.resolve(reportingDir, 'coverage' + pidExt + '.raw.json'),
+      missingFiles,
+      finalCoverage = cov;
+
+    if (config.instrumentation.includeAllSources()) {
+      if (config.verbose) {
+        console.error("Including all sources not require'd by tests");
+      }
+      missingFiles = [];
+      // Files that are not touched by code ran by the test runner is manually instrumented, to
+      // illustrate the missing coverage.
+      matchFn.files.forEach(function (file) {
+        if (!cov[file]) {
+          missingFiles.push(file);
+        }
+      });
+
+      fakeRequire = true;
+      missingFiles.forEach(function (file) {
+        try {
+          require(file);
+        } catch (ex) {
+          console.error('Unable to post-instrument: ' + file);
+        }
+      });
+    }
+    if (Object.keys(finalCoverage).length > 0) {
+      if (config.verbose) {
+        console.error('=============================================================================');
+        console.error('Writing coverage object [' + file + ']');
+        console.error('Writing coverage reports at [' + reportingDir + ']');
+        console.error('=============================================================================');
+      }
+      fs.writeFileSync(file, JSON.stringify(finalCoverage), 'utf8');
+    }
+    return finalCoverage;
+  };
+
+  exitFn = function (matchFn, reporterOpts) {
+    var cov,
+      coverageMap,
+      transformed;
+
+    cov = coverageFinderFn() || {};
+    cov = beforeReportFn(matchFn, cov);
+    coverageSetterFn(cov);
+
+    if (!(cov && typeof cov === 'object') || Object.keys(cov).length === 0) {
+      console.error('No coverage information was collected, exit without writing coverage information');
+      return;
     }
 
-    var includePid = config.instrumentation.includePid(),
-        reportingDir = path.resolve(config.reporting.dir()),
-        reporter = new Reporter(config),
-        excludes = config.instrumentation.excludes(true),
-        coverageVar = '$$cov_' + new Date().getTime() + '$$',
-        instOpts = config.instrumentation.getInstrumenterOpts(),
-        sourceMapStore = libSourceMaps.createSourceMapStore({}),
-        instrumenter,
-        runInThisContextTransformer,
-        fakeRequire,
-        requireTransformer,
-        reportInitFn,
-        hookFn,
-        unhookFn,
-        coverageFinderFn,
-        coverageSetterFn,
-        beforeReportFn,
-        exitFn;
+    coverageMap = libCoverage.createCoverageMap(cov);
+    transformed = sourceMapStore.transformCoverage(coverageMap);
+    reporterOpts.sourceFinder = transformed.sourceFinder;
+    reporter.write(transformed.map, reporterOpts);
+    sourceMapStore.dispose();
+  };
 
-    instOpts.coverageVariable = coverageVar;
-    instOpts.sourceMapUrlCallback = function (file, url) {
-        sourceMapStore.registerURL(file, url);
-    };
-    coverageFinderFn = function () {
-        return global[coverageVar];
-    };
-    instrumenter = libInstrument.createInstrumenter(instOpts);
-    runInThisContextTransformer = function (code, options) {
-      return instrumenter.instrumentSync(code, options.filename);
-    };
-    requireTransformer = function (code, options) {
-        var cov,
-          ret = instrumenter.instrumentSync(code, options.filename);
-        if (fakeRequire) {
-            cov = coverageFinderFn();
-            cov[options.filename] = instrumenter.lastFileCoverage();
-            return 'function x() {}';
-        }
-        return ret;
-    };
-
-    coverageSetterFn = function (cov) {
-        global[coverageVar] = cov;
-    };
-
-    reportInitFn = function () {
-        // set up reporter
-        mkdirp.sync(reportingDir); //ensure we fail early if we cannot do this
-        reporter.addAll(config.reporting.reports());
-        if (config.reporting.print() !== 'none') {
-            switch (config.reporting.print()) {
-                case 'detail':
-                    reporter.add('text');
-                    break;
-                case 'both':
-                    reporter.add('text');
-                    reporter.add('text-summary');
-                    break;
-                default:
-                    reporter.add('text-summary');
-                    break;
-            }
-        }
-    };
-
-    var disabler;
-    hookFn = function (matchFn) {
-        var hookOpts = {
-            verbose: config.verbose,
-            extensions: config.instrumentation.extensions()
-        };
-
-        //initialize the global variable
-        coverageSetterFn({});
-        reportInitFn();
-        console.log(config.hooks.hookRunInContext);
-        console.log(config.hooks.hookRunInContext());
-        if (config.hooks.hookRunInContext()) {
-          hook.hookRunInThisContext(matchFn, runInThisContextTransformer, hookOpts);
-        }
-        disabler = hook.hookRequire(matchFn, requireTransformer, hookOpts);
-    };
-
-    unhookFn = function (matchFn) {
-        if (disabler) {
-            disabler();
-        }
-        hook.unhookRunInThisContext();
-        hook.unloadRequireCache(matchFn);
-    };
-
-    beforeReportFn = function (matchFn, cov) {
-        var pidExt = includePid ? ('-' + process.pid) : '',
-            file = path.resolve(reportingDir, 'coverage' + pidExt + '.raw.json'),
-            missingFiles,
-            finalCoverage = cov;
-
-        if (config.instrumentation.includeAllSources()) {
-            if (config.verbose) {
-                console.error("Including all sources not require'd by tests");
-            }
-            missingFiles = [];
-            // Files that are not touched by code ran by the test runner is manually instrumented, to
-            // illustrate the missing coverage.
-            matchFn.files.forEach(function (file) {
-                if (!cov[file]) {
-                    missingFiles.push(file);
-                }
-            });
-
-            fakeRequire = true;
-            missingFiles.forEach(function (file) {
-                try {
-                    require(file);
-                } catch (ex) {
-                    console.error('Unable to post-instrument: ' + file);
-                }
-            });
-        }
-        if (Object.keys(finalCoverage).length >0) {
-            if (config.verbose) {
-                console.error('=============================================================================');
-                console.error('Writing coverage object [' + file + ']');
-                console.error('Writing coverage reports at [' + reportingDir + ']');
-                console.error('=============================================================================');
-            }
-            fs.writeFileSync(file, JSON.stringify(finalCoverage), 'utf8');
-        }
-        return finalCoverage;
-    };
-
-    exitFn = function (matchFn, reporterOpts) {
-        var cov,
-            coverageMap,
-            transformed;
-
-        cov = coverageFinderFn() || {};
-        cov = beforeReportFn(matchFn, cov);
-        coverageSetterFn(cov);
-
-        if (!(cov && typeof cov === 'object') || Object.keys(cov).length === 0) {
-            console.error('No coverage information was collected, exit without writing coverage information');
-            return;
-        }
-
-        coverageMap = libCoverage.createCoverageMap(cov);
-        transformed = sourceMapStore.transformCoverage(coverageMap);
-        reporterOpts.sourceFinder = transformed.sourceFinder;
-        reporter.write(transformed.map, reporterOpts);
-        sourceMapStore.dispose();
-    };
-
-    excludes.push(path.relative(process.cwd(), path.join(reportingDir, '**', '*')));
-    includes = includes || config.instrumentation.extensions().map(function (ext) {
-            return '**/*' + ext;
-        });
-    var matchConfig = {
-        root: config.instrumentation.root() || /* istanbul ignore next: untestable */ process.cwd(),
-        includes: includes,
-        excludes: excludes
-    };
-    matcherFor(matchConfig, function (err, matchFn) {
-        /* istanbul ignore if: untestable */
-        if (err) {
-            return callback(err);
-        }
-        return callback(null, {
-            coverageFn: coverageFinderFn,
-            hookFn: hookFn.bind(null, matchFn),
-            exitFn: exitFn.bind(null, matchFn, {}), // XXX: reporter opts
-            unhookFn: unhookFn.bind(null, matchFn)
-        });
+  excludes.push(path.relative(process.cwd(), path.join(reportingDir, '**', '*')));
+  includes = includes || config.instrumentation.extensions().map(function (ext) {
+    return '**/*' + ext;
+  });
+  var matchConfig = {
+    root: config.instrumentation.root() || /* istanbul ignore next: untestable */ process.cwd(),
+    includes: includes,
+    excludes: excludes
+  };
+  matcherFor(matchConfig, function (err, matchFn) {
+    /* istanbul ignore if: untestable */
+    if (err) {
+      return callback(err);
+    }
+    return callback(null, {
+      coverageFn: coverageFinderFn,
+      hookFn: hookFn.bind(null, matchFn),
+      exitFn: exitFn.bind(null, matchFn, {}), // XXX: reporter opts
+      unhookFn: unhookFn.bind(null, matchFn)
     });
+  });
 }
 
 module.exports = {
-    getCoverFunctions: getCoverFunctions
+  getCoverFunctions: getCoverFunctions
 };
-

--- a/packages/istanbul-api/test/run-check-coverage.test.js
+++ b/packages/istanbul-api/test/run-check-coverage.test.js
@@ -16,9 +16,6 @@ describe('run check-coverage', function () {
     function getConfig(overrides) {
         var cfg = configuration.loadObject({
             verbose: false,
-            hooks: {
-                'hook-run-in-context': true
-            },
             instrumentation: {
                 root: codeRoot,
                 'include-all-sources': true

--- a/packages/istanbul-api/test/sample-code/context.js
+++ b/packages/istanbul-api/test/sample-code/context.js
@@ -4,4 +4,4 @@ var vm = require('vm'),
     file = path.resolve(__dirname, 'foo.js'),
     code = fs.readFileSync(file, 'utf8');
 
-vm.runInThisContext(code, file);
+vm.runInThisContext(code, { filename: file });

--- a/packages/istanbul-lib-hook/lib/hook.js
+++ b/packages/istanbul-lib-hook/lib/hook.js
@@ -3,42 +3,43 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 var path = require('path'),
-    vm = require('vm'),
-    appendTransform = require('append-transform'),
-    originalRunInThisContext = vm.runInThisContext;
+  vm = require('vm'),
+  appendTransform = require('append-transform'),
+  originalCreateScript = vm.createScript,
+  originalRunInThisContext = vm.runInThisContext;
 
 function transformFn(matcher, transformer, verbose) {
 
-    return function (code, options) {
-      options = options || {};
-      if (typeof options === 'string') {
-        options = { filename: options };
+  return function (code, options) {
+    options = options || {};
+    if (typeof options === 'string') {
+      options = { filename: options };
+    }
+
+    var shouldHook = typeof options.filename === 'string' && matcher(path.resolve(options.filename)),
+      transformed,
+      changed = false;
+
+    if (shouldHook) {
+      if (verbose) {
+        console.log('Module load hook: transform [' + options.filename + ']');
       }
-
-      var shouldHook = typeof options.filename === 'string' && matcher(path.resolve(options.filename)),
-            transformed,
-            changed = false;
-
-        if (shouldHook) {
-            if (verbose) {
-              console.log('Module load hook: transform [' + options.filename + ']');
-            }
-            try {
-              transformed = transformer(code, options);
-                changed = true;
-            } catch (ex) {
-              console.error('Transformation error for', options.filename, '; return original code');
-                console.error(ex.message || String(ex));
-                if (verbose) {
-                    console.error(ex.stack);
-                }
-                transformed = code;
-            }
-        } else {
-            transformed = code;
+      try {
+        transformed = transformer(code, options);
+        changed = true;
+      } catch (ex) {
+        console.error('Transformation error for', options.filename, '; return original code');
+        console.error(ex.message || String(ex));
+        if (verbose) {
+          console.error(ex.stack);
         }
-        return { code: transformed, changed: changed };
-    };
+        transformed = code;
+      }
+    } else {
+      transformed = code;
+    }
+    return { code: transformed, changed: changed };
+  };
 }
 /**
  * unloads the required caches, removing all files that would have matched
@@ -47,14 +48,14 @@ function transformFn(matcher, transformer, verbose) {
  *  returns if that file should be unloaded from the cache.
  */
 function unloadRequireCache(matcher) {
-    /* istanbul ignore else: impossible to test */
-    if (matcher && typeof require !== 'undefined' && require && require.cache) {
-        Object.keys(require.cache).forEach(function (filename) {
-            if (matcher(filename)) {
-                delete require.cache[filename];
-            }
-        });
-    }
+  /* istanbul ignore else: impossible to test */
+  if (matcher && typeof require !== 'undefined' && require && require.cache) {
+    Object.keys(require.cache).forEach(function (filename) {
+      if (matcher(filename)) {
+        delete require.cache[filename];
+      }
+    });
+  }
 }
 /**
  * hooks `require` to return transformed code to the node module loader.
@@ -72,31 +73,60 @@ function unloadRequireCache(matcher) {
  * @returns {Function} a reset function that can be called to remove the hook
  */
 function hookRequire(matcher, transformer, options) {
-    options = options || {};
-    var extensions,
-        disable = false,
-        fn = transformFn(matcher, transformer, options.verbose),
-        postLoadHook = options.postLoadHook &&
-            typeof options.postLoadHook === 'function' ? options.postLoadHook : null;
+  options = options || {};
+  var extensions,
+    disable = false,
+    fn = transformFn(matcher, transformer, options.verbose),
+    postLoadHook = options.postLoadHook &&
+    typeof options.postLoadHook === 'function' ? options.postLoadHook : null;
 
-    extensions = options.extensions || ['.js'];
+  extensions = options.extensions || ['.js'];
 
-    extensions.forEach(function(ext){
-        appendTransform(function (code, filename) {
-            if (disable) {
-                return code;
-            }
-            var ret = fn(code, filename);
-            if (postLoadHook) {
-                postLoadHook(filename);
-            }
-            return ret.code;
-        }, ext);
-    });
+  extensions.forEach(function(ext){
+    appendTransform(function (code, filename) {
+      if (disable) {
+        return code;
+      }
+      var ret = fn(code, filename);
+      if (postLoadHook) {
+        postLoadHook(filename);
+      }
+      return ret.code;
+    }, ext);
+  });
 
-    return function () {
-        disable = true;
-    };
+  return function () {
+    disable = true;
+  };
+}
+
+/**
+ * hooks `vm.createScript` to return transformed code out of which a `Script` object will be created.
+ * Exceptions in the transform result in the original code being used instead.
+ * @method hookCreateScript
+ * @static
+ * @param matcher {Function(filePath)} a function that is called with the filename passed to `vm.createScript`
+ *  Should return a truthy value when transformations need to be applied to the code, a falsy value otherwise
+ * @param transformer {Function(code, filePath)} a function called with the original code and the filename passed to
+ *  `vm.createScript`. Should return the transformed code.
+ * @param options {Object} options Optional.
+ * @param {Boolean} [options.verbose] write a line to standard error every time the transformer is called
+ */
+function hookCreateScript(matcher, transformer, opts) {
+  opts = opts || {};
+  var fn = transformFn(matcher, transformer, opts.verbose);
+  vm.createScript = function (code, file) {
+    var ret = fn(code, file);
+    return originalCreateScript(ret.code, file);
+  };
+}
+/**
+ * unhooks vm.createScript, restoring it to its original state.
+ * @method unhookCreateScript
+ * @static
+ */
+function unhookCreateScript() {
+  vm.createScript = originalCreateScript;
 }
 
 /**
@@ -111,12 +141,12 @@ function hookRequire(matcher, transformer, options) {
  * @param {Boolean} [opts.verbose] write a line to standard error every time the transformer is called
  */
 function hookRunInThisContext(matcher, transformer, opts) {
-    opts = opts || {};
-    var fn = transformFn(matcher, transformer, opts.verbose);
-    vm.runInThisContext = function (code, options) {
-      var ret = fn(code, options);
-      return originalRunInThisContext(ret.code, options);
-    };
+  opts = opts || {};
+  var fn = transformFn(matcher, transformer, opts.verbose);
+  vm.runInThisContext = function (code, options) {
+    var ret = fn(code, options);
+    return originalRunInThisContext(ret.code, options);
+  };
 }
 /**
  * unhooks vm.runInThisContext, restoring it to its original state.
@@ -124,7 +154,7 @@ function hookRunInThisContext(matcher, transformer, opts) {
  * @static
  */
 function unhookRunInThisContext() {
-    vm.runInThisContext = originalRunInThisContext;
+  vm.runInThisContext = originalRunInThisContext;
 }
 /**
  * istanbul-lib-hook provides mechanisms to transform code in the scope of `require`,
@@ -149,10 +179,10 @@ function unhookRunInThisContext() {
  * var foo = require('foo'); //will now print foo's module path to console
  */
 module.exports = {
-    hookRequire: hookRequire,
-    hookRunInThisContext : hookRunInThisContext,
-    unhookRunInThisContext : unhookRunInThisContext,
-    unloadRequireCache: unloadRequireCache
+  hookRequire: hookRequire,
+  hookCreateScript: hookCreateScript,
+  unhookCreateScript: unhookCreateScript,
+  hookRunInThisContext: hookRunInThisContext,
+  unhookRunInThisContext: unhookRunInThisContext,
+  unloadRequireCache: unloadRequireCache
 };
-
-

--- a/packages/istanbul-lib-hook/test/hook.test.js
+++ b/packages/istanbul-lib-hook/test/hook.test.js
@@ -1,151 +1,168 @@
 /* globals describe, it, beforeEach, afterEach */
 var hook = require('../lib/hook'),
-    assert = require('chai').assert,
-    currentHook,
-    matcher = function (file) {
-        return file.indexOf('foo.js') > 0;
-    },
-    matcher2 = function (file) {
-        return file.indexOf('bar.es6') > 0;
-    },
-    transformer = function () {
-        return 'module.exports.bar = function () { return "bar"; };';
-    },
-    transformer2 = function () {
-        return 'module.exports.blah = function () { return "blah"; };';
-    },
-    badTransformer = function () {
-        throw "Boo!";
-    },
-    scriptTransformer = function () {
-        return '(function () { return 42; }());';
-    },
-    disabler,
-    hookIt = function (m, t, o) {
-        if (disabler) {
-            disabler();
-        }
-        disabler = hook.hookRequire(m, t, o);
-    };
+  assert = require('chai').assert,
+  currentHook,
+  matcher = function (file) {
+    return file.indexOf('foo.js') > 0;
+  },
+  matcher2 = function (file) {
+    return file.indexOf('bar.es6') > 0;
+  },
+  transformer = function () {
+    return 'module.exports.bar = function () { return "bar"; };';
+  },
+  transformer2 = function () {
+    return 'module.exports.blah = function () { return "blah"; };';
+  },
+  badTransformer = function () {
+    throw "Boo!";
+  },
+  scriptTransformer = function () {
+    return '(function () { return 42; }());';
+  },
+  disabler,
+  hookIt = function (m, t, o) {
+    if (disabler) {
+      disabler();
+    }
+    disabler = hook.hookRequire(m, t, o);
+  };
 
 describe('hooks', function () {
-    describe('require', function () {
-        beforeEach(function () {
-            hookIt(matcher, transformer, {verbose: true});
-        });
-
-        afterEach(function () {
-            hook.unloadRequireCache(matcher);
-        });
-
-        it('transforms foo', function () {
-            var foo = require('./data/foo');
-            assert.ok(foo.bar);
-            assert.equal(foo.bar(), 'bar');
-        });
-
-        it('skips baz', function () {
-            var foo = require('./data/baz');
-            assert.ok(foo.baz);
-            assert.equal(foo.baz(), 'baz');
-        });
-
-        it('should require original code when unhooked', function () {
-            hookIt(matcher, transformer, {verbose: true});
-            disabler();
-            var foo = require('./data/foo');
-            assert.ok(foo.foo);
-            assert.equal(foo.foo(), 'foo');
-        });
-
-        it('calls post load hooks', function () {
-            var called = null,
-                opts = {
-                    postLoadHook: function (file) {
-                        called = file;
-                    }
-                };
-
-            hookIt(matcher, transformer, opts);
-            require('./data/foo');
-            assert.ok(called.match(/foo\.js/));
-        });
-
-        it('unloads and reloads cache', function () {
-            hookIt(matcher, transformer2);
-            var foo = require('./data/foo');
-            assert.ok(foo.blah);
-            assert.equal(foo.blah(), 'blah');
-        });
-
-        it('returns original code on bad transform', function () {
-            hookIt(matcher, badTransformer);
-            var foo = require('./data/foo');
-            assert.ok(foo.foo);
-            assert.equal(foo.foo(), 'foo');
-        });
+  describe('require', function () {
+    beforeEach(function () {
+      hookIt(matcher, transformer, {verbose: true});
     });
-    describe('passing extensions to require', function () {
-        beforeEach(function () {
-            require.extensions['.es6'] = require.extensions['.js'];
-            hookIt(matcher2, transformer2, {
-                verbose: true,
-                extensions: ['.es6']
-            });
-        });
-        afterEach(function () {
-            hook.unloadRequireCache(matcher2);
-            delete require.extensions['.es6'];
-        });
-        it('transforms bar', function () {
-            var bar = require('./data/bar');
-            assert.ok(bar.blah);
-            assert.equal(bar.blah(), 'blah');
-        });
-        it('skips foo', function () {
-            var foo = require('./data/foo');
-            assert.ok(foo.foo);
-            assert.equal(foo.foo(), 'foo');
-        });
-        it('returns original code on bad transform', function () {
-            hookIt(matcher2, badTransformer, {
-                verbose: true,
-                extensions: ['.es6']
-            });
-            var bar = require('./data/bar');
-            assert.ok(bar.bar);
-            assert.equal(bar.bar(), 'bar');
-        });
+
+    afterEach(function () {
+      hook.unloadRequireCache(matcher);
     });
-    describe('runInThisContext', function () {
-        beforeEach(function () {
-            currentHook = require('vm').runInThisContext;
-        });
-        afterEach(function () {
-            require('vm').runInThisContext = currentHook;
-        });
-        it('transforms foo', function () {
-            var s;
-            hook.hookRunInThisContext(matcher, scriptTransformer);
-            s = require('vm').runInThisContext('(function () { return 10; }());', { filename:'/bar/foo.js' });
-            assert.equal(s, 42);
-            hook.unhookRunInThisContext();
-            s = require('vm').runInThisContext('(function () { return 10; }());', { filename: '/bar/foo.js' });
-            assert.equal(s, 10);
-        });
-        it('does not transform code with no filename', function () {
-            var s;
-            hook.hookRunInThisContext(matcher, scriptTransformer);
-            s = require('vm').runInThisContext('(function () { return 10; }());');
-            assert.equal(s, 10);
-            hook.unhookRunInThisContext();
-        });
-        it('does not transform code with non-string filename', function () {
-            var s;
-            hook.hookRunInThisContext(matcher, scriptTransformer);
-            s = require('vm').runInThisContext('(function () { return 10; }());', {});
-            assert.equal(s, 10);
-            hook.unhookRunInThisContext();
-        });
+
+    it('transforms foo', function () {
+      var foo = require('./data/foo');
+      assert.ok(foo.bar);
+      assert.equal(foo.bar(), 'bar');
     });
+
+    it('skips baz', function () {
+      var foo = require('./data/baz');
+      assert.ok(foo.baz);
+      assert.equal(foo.baz(), 'baz');
+    });
+
+    it('should require original code when unhooked', function () {
+      hookIt(matcher, transformer, {verbose: true});
+      disabler();
+      var foo = require('./data/foo');
+      assert.ok(foo.foo);
+      assert.equal(foo.foo(), 'foo');
+    });
+
+    it('calls post load hooks', function () {
+      var called = null,
+        opts = {
+          postLoadHook: function (file) {
+            called = file;
+          }
+        };
+
+      hookIt(matcher, transformer, opts);
+      require('./data/foo');
+      assert.ok(called.match(/foo\.js/));
+    });
+
+    it('unloads and reloads cache', function () {
+      hookIt(matcher, transformer2);
+      var foo = require('./data/foo');
+      assert.ok(foo.blah);
+      assert.equal(foo.blah(), 'blah');
+    });
+
+    it('returns original code on bad transform', function () {
+      hookIt(matcher, badTransformer);
+      var foo = require('./data/foo');
+      assert.ok(foo.foo);
+      assert.equal(foo.foo(), 'foo');
+    });
+  });
+  describe('passing extensions to require', function () {
+    beforeEach(function () {
+      require.extensions['.es6'] = require.extensions['.js'];
+      hookIt(matcher2, transformer2, {
+        verbose: true,
+        extensions: ['.es6']
+      });
+    });
+    afterEach(function () {
+      hook.unloadRequireCache(matcher2);
+      delete require.extensions['.es6'];
+    });
+    it('transforms bar', function () {
+      var bar = require('./data/bar');
+      assert.ok(bar.blah);
+      assert.equal(bar.blah(), 'blah');
+    });
+    it('skips foo', function () {
+      var foo = require('./data/foo');
+      assert.ok(foo.foo);
+      assert.equal(foo.foo(), 'foo');
+    });
+    it('returns original code on bad transform', function () {
+      hookIt(matcher2, badTransformer, {
+        verbose: true,
+        extensions: ['.es6']
+      });
+      var bar = require('./data/bar');
+      assert.ok(bar.bar);
+      assert.equal(bar.bar(), 'bar');
+    });
+  });
+  describe('createScript', function () {
+    beforeEach(function () {
+      currentHook = require('vm').createScript;
+    });
+    afterEach(function () {
+      require('vm').createScript = currentHook;
+    });
+    it('transforms foo (without any options)', function () {
+      var s;
+      hook.hookCreateScript(matcher, scriptTransformer);
+      s = require('vm').createScript('(function () { return 10; }());', '/bar/foo.js');
+      assert.equal(s.runInThisContext(), 42);
+      hook.unhookCreateScript();
+      s = require('vm').createScript('(function () { return 10; }());', '/bar/foo.js');
+      assert.equal(s.runInThisContext(), 10);
+    });
+  });
+  describe('runInThisContext', function () {
+    beforeEach(function () {
+      currentHook = require('vm').runInThisContext;
+    });
+    afterEach(function () {
+      require('vm').runInThisContext = currentHook;
+    });
+    it('transforms foo', function () {
+      var s;
+      hook.hookRunInThisContext(matcher, scriptTransformer);
+      s = require('vm').runInThisContext('(function () { return 10; }());', { filename: '/bar/foo.js' });
+      assert.equal(s, 42);
+      hook.unhookRunInThisContext();
+      s = require('vm').runInThisContext('(function () { return 10; }());', { filename: '/bar/foo.js' });
+      assert.equal(s, 10);
+    });
+    it('does not transform code with no filename', function () {
+      var s;
+      hook.hookRunInThisContext(matcher, scriptTransformer);
+      s = require('vm').runInThisContext('(function () { return 10; }());');
+      assert.equal(s, 10);
+      hook.unhookRunInThisContext();
+    });
+    it('does not transform code with non-string filename', function () {
+      var s;
+      hook.hookRunInThisContext(matcher, scriptTransformer);
+      s = require('vm').runInThisContext('(function () { return 10; }());', {});
+      assert.equal(s, 10);
+      hook.unhookRunInThisContext();
+    });
+  });
 });

--- a/packages/istanbul-lib-hook/test/hook.test.js
+++ b/packages/istanbul-lib-hook/test/hook.test.js
@@ -117,23 +117,6 @@ describe('hooks', function () {
             assert.equal(bar.bar(), 'bar');
         });
     });
-    describe('createScript', function () {
-        beforeEach(function () {
-            currentHook = require('vm').createScript;
-        });
-        afterEach(function () {
-            require('vm').createScript = currentHook;
-        });
-        it('transforms foo (without any options)', function () {
-            var s;
-            hook.hookCreateScript(matcher, scriptTransformer);
-            s = require('vm').createScript('(function () { return 10; }());', '/bar/foo.js');
-            assert.equal(s.runInThisContext(), 42);
-            hook.unhookCreateScript();
-            s = require('vm').createScript('(function () { return 10; }());', '/bar/foo.js');
-            assert.equal(s.runInThisContext(), 10);
-        });
-    });
     describe('runInThisContext', function () {
         beforeEach(function () {
             currentHook = require('vm').runInThisContext;
@@ -144,10 +127,10 @@ describe('hooks', function () {
         it('transforms foo', function () {
             var s;
             hook.hookRunInThisContext(matcher, scriptTransformer);
-            s = require('vm').runInThisContext('(function () { return 10; }());', '/bar/foo.js');
+            s = require('vm').runInThisContext('(function () { return 10; }());', { filename:'/bar/foo.js' });
             assert.equal(s, 42);
             hook.unhookRunInThisContext();
-            s = require('vm').runInThisContext('(function () { return 10; }());', '/bar/foo.js');
+            s = require('vm').runInThisContext('(function () { return 10; }());', { filename: '/bar/foo.js' });
             assert.equal(s, 10);
         });
         it('does not transform code with no filename', function () {
@@ -155,14 +138,14 @@ describe('hooks', function () {
             hook.hookRunInThisContext(matcher, scriptTransformer);
             s = require('vm').runInThisContext('(function () { return 10; }());');
             assert.equal(s, 10);
-            hook.unhookCreateScript();
+            hook.unhookRunInThisContext();
         });
         it('does not transform code with non-string filename', function () {
             var s;
             hook.hookRunInThisContext(matcher, scriptTransformer);
             s = require('vm').runInThisContext('(function () { return 10; }());', {});
             assert.equal(s, 10);
-            hook.unhookCreateScript();
+            hook.unhookRunInThisContext();
         });
     });
 });


### PR DESCRIPTION
Fix #89 hook runInThisContext to use options as argument instead of  filename (cf [vm documentation](https://nodejs.org/api/vm.html#vm_vm_runinthiscontext_code_options))

Delete unusable and unused hook on createScript : instead use constructor [new Script](https://nodejs.org/api/vm.html#vm_new_vm_script_code_options)

