### PR TITLE
deps: upgrade debug package

### DIFF
--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "^2.6.3",
+    "debug": "^3.1.0",
     "istanbul-lib-coverage": "^1.1.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Due to https://nodesecurity.io/advisories/534

It's a major version bump, but looking at the changelog I don't
see any breaking changes of note.