### PR TITLE
Remove call to mkdirp.sync() in FileWriter constructor

### DIFF
--- a/packages/istanbul-lib-report/lib/file-writer.js
+++ b/packages/istanbul-lib-report/lib/file-writer.js
@@ -119,7 +119,6 @@ function FileWriter(baseDir) {
     if (!baseDir) {
         throw new Error('baseDir must be specified');
     }
-    mkdirp.sync(baseDir);
     this.baseDir = baseDir;
 }
 


### PR DESCRIPTION
When `FileWriter` is used to get a `ConsoleWriter` (such as in the text report), the call to `mkdirp.sync()` in the constructor creates a directory that is never used. `FileWriter#copyFile()` and `FileWriter#writeFile()` already call `mkdirp.sync()` before writing files, so the call in the constructor isn't needed anyway.