### PR TITLE
feat: add support for ignoring entire files

### DIFF
--- a/packages/istanbul-lib-instrument/test/specs.test.js
+++ b/packages/istanbul-lib-instrument/test/specs.test.js
@@ -62,14 +62,18 @@ function generateTests(docs) {
                 (doc.tests || []).forEach(function (t) {
                     var fn =  function () {
                         var genOnly = (doc.opts || {}).generateOnly,
+                            noCoverage = (doc.opts || {}).noCoverage,
                             v = verifier.create(doc.code, doc.opts || {}, doc.instrumentOpts, doc.inputSourceMap),
                             test = clone(t),
                             args = test.args,
                             out = test.out;
                         delete test.args;
                         delete test.out;
-                        if (!genOnly) {
+                        if (!genOnly && !noCoverage) {
                             v.verify(args, out, test);
+                        }
+                        if (noCoverage) {
+                            assert.equal(v.code, v.generatedCode);
                         }
                     };
                     if (skip) {

--- a/packages/istanbul-lib-instrument/test/specs/ignore.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/ignore.yaml
@@ -1,0 +1,9 @@
+---
+name: ignore file comment
+code: |
+  /* istanbul ignore file */
+  output = true === true ? "works" : "doesn't work"
+opts:
+  noCoverage: true
+tests:
+  - name: file is ignored

--- a/packages/istanbul-lib-instrument/test/util/verifier.js
+++ b/packages/istanbul-lib-instrument/test/util/verifier.js
@@ -94,6 +94,7 @@ function create(code, opts, instrumenterOpts, inputSourceMap) {
     var debug = extractTestOption(opts, 'debug', process.env.DEBUG==="1"),
         file = extractTestOption(opts, 'file', __filename),
         generateOnly = extractTestOption(opts, 'generateOnly', false),
+        noCoverage = extractTestOption(opts, 'noCoverage', false),
         quiet = extractTestOption(opts, 'quiet', false),
         coverageVariable = instrumenterOpts.coverageVariable,
         g = getGlobalObject(),
@@ -133,7 +134,7 @@ function create(code, opts, instrumenterOpts, inputSourceMap) {
             verror = new Error('Error compiling\n' + annotatedCode(code) + '\n' + ex.message);
         }
     }
-    if (generateOnly) {
+    if (generateOnly || noCoverage) {
         assert.ok(!verror);
     }
     return new Verifier({


### PR DESCRIPTION
Sometimes in my projects I'll have one or two files that I don't want to have coverage for. It's annoying to have to edit the config to just ignore one or two files (especially if that config is hidden away in another tool).

This PR adds a feature for ignoring entire files by allowing you to add a comment: `/* istanbul ignore file */` and it will skip instrumenting the entire file.

To do this, I create another regex especially for this full file ignore, then in the program enter and exit visitor, we check whether the parent of the program node (the file node) has any comments which match this regex. If it does, then we'll skip doing any instrumentation.

This PR also tests this functionality with a new `specs/ignore.yaml`. It requires adding a new option called `noCoverage` which functions similar to `generateOnly` except it adds an assertion that the input code is the same as the output (because it hasn't been altered).

I've tested this locally and it works great!
 
<img width="667" alt="screen shot 2017-10-16 at 5 26 30 pm" src="https://user-images.githubusercontent.com/1500684/31639682-2d230694-b297-11e7-906c-9cd59c6238ac.png">

I normally would have opened an issue for this, but I thought it'd be pretty small :) I'm happy to iterate on this a bit.