### PR TITLE
fix: address issue with class instrumentation

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -436,7 +436,7 @@ const codeVisitor = {
     AssignmentPattern: entries(coverAssignmentPattern),
     BlockStatement: entries(), // ignore processing only
     ClassMethod: entries(coverFunction),
-    ClassDeclaration: entries(parenthesizedExpressionProp('superClass'), coverStatement),
+    ClassDeclaration: entries(parenthesizedExpressionProp('superClass')),
     ExpressionStatement: entries(coverStatement),
     BreakStatement: entries(coverStatement),
     ContinueStatement: entries(coverStatement),

--- a/packages/istanbul-lib-instrument/test/specs/classes.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/classes.yaml
@@ -20,7 +20,7 @@ code: |
 tests:
   - name: properly instruments code
     out: 'MyClass'
-    lines: {'1': 1, '2': 1}
+    lines: {'2': 1}
     functions: {}
-    statements: {'0': 1, '1': 1}
+    statements: {'0': 1}
     branches: {'0': [1, 0]}

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -131,4 +131,15 @@ describe('varia', function () {
             assert.ok(!generated);
         });
     });
+
+    // see: https://github.com/istanbuljs/istanbuljs/issues/110
+    // TODO: it feels like we should be inserting line counters
+    // for class exports and class declarations.
+    it('properly exports named classes', function () {
+        var v = verifier.create('export class App extends Component {};', { generateOnly: true }, { esModules: true }),
+            code;
+        assert.ok(!v.err);
+        code = v.getGeneratedCode();
+        assert.ok(code.match(/cov_(.+);export class App extends/));
+    });
 });


### PR DESCRIPTION
prior to the regression in `1.9` it looks like we didn't add line counters to functions or classes. It seems like we should eventually do this, but there are a bunch of caveats around this that we need to address -- related to exports vs. non exports, etc.

This rolls back any attempt to instrument classes for line coverage at this time.

fixes #110