### PR TITLE
Fixes proper passing of the preserveComments option to babel

### DIFF
--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -106,6 +106,7 @@ class Instrumenter {
 
         const generateOptions = {
             compact: opts.compact,
+            comments: opts.preserveComments,
             sourceMaps: opts.produceSourceMap,
             sourceFileName: filename
         };

--- a/packages/istanbul-lib-instrument/test/index.test.js
+++ b/packages/istanbul-lib-instrument/test/index.test.js
@@ -13,3 +13,15 @@ describe('external interface', function () {
         assert.isFunction(pc);
     });
 });
+
+describe('instrumenter', function() {
+    it('should remove comments when asked to', function() {
+        const instrumenter = index.createInstrumenter({
+            preserveComments: false
+        });
+        const instrumentedCode = instrumenter.instrumentSync('/*foo*/\n//bar\ncode = true', 'somefile.js');
+        assert.equal(instrumentedCode.indexOf('foo'), -1, 'block comment not removed');
+        assert.equal(instrumentedCode.indexOf('bar'), -1, 'line comment not removed');
+    });
+});
+

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -36,7 +36,7 @@ describe('varia', function () {
     });
 
     it('preserves comments when requested', function () {
-        var v = verifier.create('/* hello */\noutput = args[0];', { preserveComments: true }),
+        var v = verifier.create('/* hello */\noutput = args[0];', {}, { preserveComments: true }),
             code;
         assert.ok(!v.err);
         v.verify(['X'], 'X',{


### PR DESCRIPTION
I noticed that passing preserveComments: false to Istanbul doesn't do anything. Comments were never removed. I fixed this. The option was simply never used anywhere. Also wrote a test for it and fixed one other test

Hope my changes are OK, otherwise please let me know!