### PR TITLE
Fix fileCoverage of undefined failure

### DIFF
--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -98,7 +98,10 @@ class Instrumenter {
             Program: {
                 enter: ee.enter,
                 exit: function (path) {
-                    output = ee.exit(path);
+                    const newOutput = ee.exit(path);
+                    if (newOutput) {
+                        output = newOutput;
+                    }
                 }
             }
         };


### PR DESCRIPTION
Avoid output to be undefined and throw `Cannot read property 'fileCoverage' of undefined`