### PR TITLE
fix: fix instrumentation when a function is called Function

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -466,6 +466,7 @@ const coverageTemplate = template(`
     var COVERAGE_VAR = (function () {
         var path = PATH,
             hash = HASH,
+            Function = (function(){}).constructor,
             global = (new Function('return this'))(),
             gcv = GLOBAL_COVERAGE_VAR,
             coverageData = INITIAL,

--- a/packages/istanbul-lib-instrument/test/specs/functions.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/functions.yaml
@@ -130,3 +130,17 @@ tests:
     functions: {'0': 0, '1': 0, '2': 1, '3': 0}
     statements: {'0': 0, '1': 1, '2': 1, '3': 1}
     guard: isInferredFunctionNameAvailable
+
+---
+name: function named Function
+code: |
+  function Function () {
+    this.x = 42
+  }
+  output = new Function().x
+tests:
+  - name: does not fail if a function is called Function
+    out: 42
+    lines: {'2': 1, '4': 1}
+    functions: {'0': 1}
+    statements: {'0': 1, '1': 1}


### PR DESCRIPTION
Hi, it’s been a while! 👋 Hope y’all are doing great!

This patch makes the code a little more robust by not assuming that the instrumented code contains no function named `Function`.
  