### PR TITLE
Fix compatibility with babel 7

### DIFF
--- a/packages/istanbul-lib-instrument/src/read-coverage.js
+++ b/packages/istanbul-lib-instrument/src/read-coverage.js
@@ -29,7 +29,7 @@ export default function readInitialCoverage (code) {
                 if (!magicValue.confident || magicValue.value !== MAGIC_VALUE) {
                     return;
                 }
-                covScope = path.scope.getFunctionParent();
+                covScope = path.scope.getFunctionParent() || path.scope.getProgramParent();
                 path.stop();
             }
         }

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -541,7 +541,7 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {coverageVa
                 INITIAL: coverageNode,
                 HASH: T.stringLiteral(hash)
             });
-            cv._blockHoist = 3;
+            cv._blockHoist = 5;
             path.node.body.unshift(cv);
             return {
                 fileCoverage: coverageData,


### PR DESCRIPTION
Babel 7 does not return program scope from getFunctionParent().

This fix also still works with babel 6

https://github.com/babel/babel/pull/5923