### PR TITLE
Load custom reporters

### DIFF
--- a/packages/istanbul-reports/index.js
+++ b/packages/istanbul-reports/index.js
@@ -7,7 +7,13 @@ var path = require('path');
 module.exports = {
     create: function (name, cfg) {
         cfg = cfg || {};
-        var Cons = require(path.join(__dirname, 'lib', name));
+        var Cons;
+        try {
+          Cons = require(path.join(__dirname, 'lib', name));
+        } catch (e) {
+          Cons = require(name);
+        }
+
         return new Cons(cfg);
     }
 };


### PR DESCRIPTION
Hi,

This is my attempt to add custom reporters support to nyc:
I tried to do this as seamless and in the least obtrusive way possible in order to just make use of the `--reporter=<reporter-name>` flag in nyc.

I just want to start the ball rolling here, if you have any other idea on how to acomplish this I would be glad to roll up my sleeves and help out here.

Also made a custom reporter that is working with these changes and is working great for my use case:
https://github.com/pedrocarrico/istanbul-reporter-aws-cloudwatch-metrics

It's still a proof of concept but soon I'll add more features and tests to it.

Also linking https://github.com/istanbuljs/nyc/issues/387 here.

Many thanks,