### PR TITLE
Revert "fix: pass correct args to tranformer (#153)"

### DIFF
--- a/packages/istanbul-lib-hook/lib/hook.js
+++ b/packages/istanbul-lib-hook/lib/hook.js
@@ -26,7 +26,7 @@ function transformFn(matcher, transformer, verbose) {
                 console.error('Module load hook: transform [' + options.filename + ']');
             }
             try {
-                transformed = transformer(code, options.filename);
+                transformed = transformer(code, options);
                 changed = true;
             } catch (ex) {
                 console.error('Transformation error for', options.filename, '; return original code');

--- a/packages/istanbul-lib-hook/test/hook.test.js
+++ b/packages/istanbul-lib-hook/test/hook.test.js
@@ -1,7 +1,6 @@
 /* globals describe, it, beforeEach, afterEach */
 var hook = require('../lib/hook'),
     assert = require('chai').assert,
-    path = require('path'),
     currentHook,
     matcher = function (file) {
         return file.indexOf('foo.js') > 0;
@@ -43,19 +42,6 @@ describe('hooks', function () {
             var foo = require('./data/foo');
             assert.ok(foo.bar);
             assert.equal(foo.bar(), 'bar');
-        });
-
-        it('calls the transformer with the correct args', function () {
-            var transformerArgs;
-            function transformerStub() {
-                transformerArgs = arguments;
-                return '';
-            }
-            hookIt(matcher, transformerStub, {verbose: true});
-            require('./data/foo');
-            assert.ok(transformerArgs);
-            assert.equal(typeof transformerArgs[0], 'string');
-            assert.equal(transformerArgs[1], path.resolve(__dirname, './data/foo.js'));
         });
 
         it('skips baz', function () {


### PR DESCRIPTION
Reverts istanbuljs/istanbuljs#154 @kevinkir, @CodeTroopers reading back through #99 I note that the signature of transformer would need to change in a bunch of other places -- so landing #154 creates an inconsistent API ... I think at this point we pretty much need to just update the documentation to reflect the API change, we could release this as a breaking change and and revert `latest` back to a slightly older version of the `1.x` version of the library.

@kevinkir want to take a stab at updating the docs and API?