### PR TITLE
fix: parenthesize superClass on non-idetifier case

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -339,16 +339,16 @@ function blockProp(prop) {
     };
 }
 
-function makeParenthesizedExpression(path) {
-  var T = this.types;
-  if (path.node) {
-    path.replaceWith(T.parenthesizedExpression(path.node));
-  }
+function makeParenthesizedExpressionForNonIdentifier(path) {
+    var T = this.types;
+    if (path.node && !path.isIdentifier()) {
+        path.replaceWith(T.parenthesizedExpression(path.node));
+    }
 }
 
 function parenthesizedExpressionProp(prop) {
     return function (path) {
-        makeParenthesizedExpression.call(this, path.get(prop));
+        makeParenthesizedExpressionForNonIdentifier.call(this, path.get(prop));
     };
 }
 

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -142,4 +142,12 @@ describe('varia', function () {
         code = v.getGeneratedCode();
         assert.ok(code.match(/cov_(.+);export class App extends/));
     });
+
+    it('does not add extra parenthesis when superclass is an identifier', function () {
+        var v = verifier.create('class App extends Component {};', { generateOnly: true }),
+            code;
+        assert.ok(!v.err);
+        code = v.getGeneratedCode();
+        assert.ok(code.match(/cov_(.+);class App extends Component/));
+    });
 });


### PR DESCRIPTION
Parenthesizing every superClass node will render `extendsNative` in `babel-plugin-transform-classess` useless. As we can see from the [code](https://github.com/babel/babel/blob/e2c5f25e97757cf4f7bd1527c51a9b61a29115ac/packages/babel-plugin-transform-classes/src/transformClass.js#L669), the transformer relies on a static superClass name to apply `wrapNativeSuper` helper. For example, it will transpile
```js
class MyError extends Error {
  constructor() {
    super("hey");
  }
}
```
into
```js
var MyError =
/*#__PURE__*/
function (_Error) {
  _inherits(MyError, _Error);

  function MyError() {
    _classCallCheck(this, MyError);

    return _possibleConstructorReturn(this, (MyError.__proto__ || Object.getPrototypeOf(MyError)).call(this, "hey"));
  }

  return MyError;
}(_wrapNativeSuper(Error));
```
Here is a living [example](https://babeljs.io/repl/#?babili=false&browsers=Chrome%20%3E%3D%2045%2Clast%202%20Firefox%20versions%2Cie%20%3E%3D%209%2CEdge%20%3E%3D%2012%2CiOS%20%3E%3D%209%2CAndroid%20%3E%3D%204%2Clast%202%20ChromeAndroid%20versions&build=&builtIns=false&code_lz=MYGwhgzhAECyCeBRATsg9s6BTAHgFywDsATGFdTAbwChppg1CI9kBXYPDACgEpoa6dCKwAOWZFwBEACyzxJPANy1oAX2rqgA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&lineWrap=true&presets=env&prettier=false&targets=&version=7.0.0-beta.36&envVersion=7.0.0-beta.36).

However, as we are parenthesizing all superClass on-the-fly even when it is simply an identifier, babel can not figure out if the super class is built-in objects. The `classState.superName` [here](https://github.com/babel/babel/blob/e2c5f25e97757cf4f7bd1527c51a9b61a29115ac/packages/babel-plugin-transform-classes/src/transformClass.js#L669) is of type `parenthesizedExpression` and thus `classState.superName.name` is `undefined`, the transpiled result will be something like

```js
var MyError =
/*#__PURE__*/
function (_ref2) {
  _inherits(MyError, _ref2);

  function MyError() {
    _classCallCheck(this, MyError);

    cov_2rm2vs9wp7.f[0]++;
    cov_2rm2vs9wp7.s[0]++; // other instrument is leaved out for brevity
    return _possibleConstructorReturn(this, (MyError.__proto__ || Object.getPrototypeOf(MyError)).call(this, "hey"));
  }

  return MyError;
}((Error));
```
The unit test of our projects fails since `Error` is not applied with `_wrapNativeSuper`.

 I don't think there is much `transformClasses` can do since the superClass can be any fancy LHS expressions, but on our side we can parenthesize superClass only when it is not an identifier. This will cover the use case of extending built-in objects without losing conditional super class support.

Note: the `extendsNative` is introduced at babel 7 beta, the babel 6 users is not affected though.

Tests are also added on the changed behaviours.