### PR TITLE
fix: 1.2.x should have been a breaking change

### DIFF
--- a/packages/istanbul-lib-hook/lib/hook.js
+++ b/packages/istanbul-lib-hook/lib/hook.js
@@ -13,6 +13,9 @@ function transformFn(matcher, transformer, verbose) {
 
     return function (code, options) {
         options = options || {};
+
+        // prior to 2.x, hookRequire returned filename
+        // rather than object.
         if (typeof options === 'string') {
             options = { filename: options };
         }


### PR DESCRIPTION
BREAKING CHANGE: the closure provied to hookRequire, hookRunInThisContext, etc., is now passed an object with a filename member, rather than a string representing filename.