### PR TITLE
fix: Instrument ObjectMethod's.

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -451,6 +451,7 @@ const codeVisitor = {
     BlockStatement: entries(), // ignore processing only
     ClassMethod: entries(coverFunction),
     ClassDeclaration: entries(parenthesizedExpressionProp('superClass')),
+    ObjectMethod: entries(coverFunction),
     ExpressionStatement: entries(coverStatement),
     BreakStatement: entries(coverStatement),
     ContinueStatement: entries(coverStatement),

--- a/packages/istanbul-lib-instrument/test/specs/object-method.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/object-method.yaml
@@ -1,0 +1,22 @@
+---
+name: object method
+code: |
+  const foo = {test() { return 'value' }}
+  output = foo.test()
+tests:
+  - name: object method is instrumented
+    out: 'value'
+    lines: {'1': 1, '2': 1}
+    functions: {'0': 1}
+    statements: {'0': 1, '1': 1, '2': 1}
+---
+name: object getter
+code: |
+  const foo = {get test() { return 'value' }}
+  output = foo.test;
+tests:
+  - name: object getter is instrumented
+    out: 'value'
+    lines: {'1': 1, '2': 1}
+    functions: {'0': 1}
+    statements: {'0': 1, '1': 1, '2': 1}


### PR DESCRIPTION
nyc currently reports the following code as containing 0 functions.  Add
ObjectMethod visitor to istanbul-lib-instrument so these are seen.

```js
const obj = {
	get prop() { return 0; }
	fn() {}
	*gen() {}
};
```