### PR TITLE
test-exclude: bump read-pkg-up dependency

### DIFF
--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -35,7 +35,10 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "minimatch": "^3.0.4",
-    "read-pkg-up": "^3.0.0",
+    "read-pkg-up": "^4.0.0",
     "require-main-filename": "^1.0.1"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
The only breaking change is that we dropped support for Node.js 4, which shouldn't affect this module since it seems like it only supports Node.js 6 and up.