### PR TITLE
feature: Update for babel 7.

### DIFF
--- a/packages/nyc-config-babel/README.md
+++ b/packages/nyc-config-babel/README.md
@@ -14,7 +14,7 @@ Then write a `.babelrc` that looks something like this:
 
 ```json
 {
-  "presets": ["env", "..., etc."],
+  "presets": ["@babel/env", "..., etc."],
   "plugins": ["istanbul"]
 }
 ```

--- a/packages/nyc-config-babel/index.json
+++ b/packages/nyc-config-babel/index.json
@@ -2,6 +2,6 @@
   "sourceMap": false,
   "instrument": false,
   "require": [
-    "babel-register"
+    "@babel/register"
   ]
 }

--- a/packages/nyc-config-babel/package.json
+++ b/packages/nyc-config-babel/package.json
@@ -26,8 +26,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "peerDependencies": {
-    "babel-plugin-istanbul": "*",
-    "babel-register": "*"
+    "babel-plugin-istanbul": ">=5",
+    "@babel/register": "*"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: This updated configuration requires babel-plugin-istanbul 5.0.0.

Now requires node >=6 per dependencies.