### PR TITLE
fix: Don't ignore src/visitor.js for self test.

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -3,9 +3,9 @@ import { SHA, MAGIC_KEY, MAGIC_VALUE } from './constants';
 import {createHash} from 'crypto';
 import template from '@babel/template';
 
-// istanbul ignore comment pattern
+// pattern for istanbul to ignore a section
 const COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/;
-// istanbul ignore file pattern
+// pattern for istanbul to ignore the whole file
 const COMMENT_FILE_RE = /^\s*istanbul\s+ignore\s+(file)(?=\W|$)/;
 // source map URL pattern
 const SOURCE_MAP_RE = /[#@]\s*sourceMappingURL=(.*)\s*$/m;


### PR DESCRIPTION
src/visitor.js contains the logic to skip files containing comments
matching 'istanbul ignore file'.  Unfortunately the comment for the
patter contained this exact word, blocking coverage from our own test.
Rewrite the comment so the file is not ignored.