### PR TITLE
chore: Specify node >= 6 in istanbul-reports.

### DIFF
--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -35,5 +35,8 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs"
+  "homepage": "https://github.com/istanbuljs/istanbuljs",
+  "engines": {
+    "node": ">=6"
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: Requires node >= 6.