### PR TITLE
feat: New option coverageGlobalScope.

### DIFF
--- a/packages/istanbul-lib-instrument/api.md
+++ b/packages/istanbul-lib-instrument/api.md
@@ -106,6 +106,8 @@ The exit function returns an object that currently has the following keys:
 -   `sourceFilePath` **[string][9]** the path to source file (optional, default `'unknown.js'`)
 -   `opts` **[Object][8]** additional options (optional, default `defaultProgramVisitorOpts`)
     -   `opts.coverageVariable` **[string][9]** the global coverage variable name. (optional, default `__coverage__`)
+    -   `opts.coverageGlobalScope` **[string][9]** the global coverage variable scope. (optional, default `this`)
+    -   `opts.coverageGlobalScopeFunc` **[boolean][10]** use an evaluated function to find coverageGlobalScope. (optional, default `true`)
     -   `opts.ignoreClassMethods` **[Array][11]** names of methods to ignore by default on classes. (optional, default `[]`)
     -   `opts.inputSourceMap` **[object][8]** the input source map, that maps the uninstrumented code back to the
         original code. (optional, default `undefined`)

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -11,6 +11,8 @@ import programVisitor from './visitor';
 export function defaultOpts() {
     return {
         coverageVariable: '__coverage__',
+        coverageGlobalScope: 'this',
+        coverageGlobalScopeFunc: true,
         preserveComments: false,
         compact: true,
         esModules: false,
@@ -96,6 +98,8 @@ class Instrumenter {
         });
         const ee = programVisitor(t, filename, {
             coverageVariable: opts.coverageVariable,
+            coverageGlobalScope: opts.coverageGlobalScope,
+            coverageGlobalScopeFunc: opts.coverageGlobalScopeFunc,
             ignoreClassMethods: opts.ignoreClassMethods,
             inputSourceMap: inputSourceMap
         });

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -2,6 +2,7 @@ import { SourceCoverage } from './source-coverage';
 import { SHA, MAGIC_KEY, MAGIC_VALUE } from './constants';
 import { createHash } from 'crypto';
 import template from '@babel/template';
+import { defaultOpts } from './instrumenter';
 
 // pattern for istanbul to ignore a section
 const COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/;
@@ -521,16 +522,22 @@ const codeVisitor = {
     ConditionalExpression: entries(coverTernary),
     LogicalExpression: entries(coverLogicalExpression)
 };
+const globalTemplateFunction = template(`
+        var Function = (function(){}).constructor;
+        var global = (new Function(GLOBAL_COVERAGE_SCOPE))();
+`);
+const globalTemplateVariable = template(`
+        var global = GLOBAL_COVERAGE_SCOPE;
+`);
 // the template to insert at the top of the program.
 const coverageTemplate = template(`
     var COVERAGE_VAR = (function () {
-        var path = PATH,
-            hash = HASH,
-            Function = (function(){}).constructor,
-            global = (new Function('return this'))(),
-            gcv = GLOBAL_COVERAGE_VAR,
-            coverageData = INITIAL,
-            coverage = global[gcv] || (global[gcv] = {});
+        var path = PATH;
+        var hash = HASH;
+        GLOBAL_COVERAGE_TEMPLATE
+        var gcv = GLOBAL_COVERAGE_VAR;
+        var coverageData = INITIAL;
+        var coverage = global[gcv] || (global[gcv] = {});
         if (coverage[path] && coverage[path].hash === hash) {
             return coverage[path];
         }
@@ -554,8 +561,6 @@ function shouldIgnoreFile(programNode) {
 }
 
 const defaultProgramVisitorOpts = {
-    coverageVariable: '__coverage__',
-    ignoreClassMethods: [],
     inputSourceMap: undefined
 };
 /**
@@ -575,6 +580,8 @@ const defaultProgramVisitorOpts = {
  * @param {string} sourceFilePath - the path to source file
  * @param {Object} opts - additional options
  * @param {string} [opts.coverageVariable=__coverage__] the global coverage variable name.
+ * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
+ * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
  * @param {Array} [opts.ignoreClassMethods=[]] names of methods to ignore by default on classes.
  * @param {object} [opts.inputSourceMap=undefined] the input source map, that maps the uninstrumented code back to the
  * original code.
@@ -585,6 +592,8 @@ function programVisitor(
     opts = defaultProgramVisitorOpts
 ) {
     const T = types;
+    // This sets some unused options but ensures all required options are initialized
+    opts = Object.assign({}, defaultOpts(), defaultProgramVisitorOpts, opts);
     const visitState = new VisitState(
         types,
         sourceFilePath,
@@ -619,8 +628,21 @@ function programVisitor(
                 .digest('hex');
             const coverageNode = T.valueToNode(coverageData);
             delete coverageData[MAGIC_KEY];
+            let gvTemplate;
+            if (opts.coverageGlobalScopeFunc) {
+                gvTemplate = globalTemplateFunction({
+                    GLOBAL_COVERAGE_SCOPE: T.stringLiteral(
+                        'return ' + opts.coverageGlobalScope
+                    )
+                });
+            } else {
+                gvTemplate = globalTemplateVariable({
+                    GLOBAL_COVERAGE_SCOPE: opts.coverageGlobalScope
+                });
+            }
             const cv = coverageTemplate({
                 GLOBAL_COVERAGE_VAR: T.stringLiteral(opts.coverageVariable),
+                GLOBAL_COVERAGE_TEMPLATE: gvTemplate,
                 COVERAGE_VAR: T.identifier(visitState.varName),
                 PATH: T.stringLiteral(sourceFilePath),
                 INITIAL: coverageNode,

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -176,4 +176,31 @@ describe('varia', function() {
         code = v.getGeneratedCode();
         assert.ok(code.match(/cov_(.+);class App extends Component/));
     });
+
+    it('can store coverage object in alternative scope', function() {
+        const opts = { generateOnly: true };
+        const instrumentOpts = { coverageGlobalScope: 'window.top' };
+        const v = verifier.create('console.log("test");', opts, instrumentOpts);
+        var code;
+        assert.ok(!v.err);
+        code = v.getGeneratedCode();
+        assert.ok(
+            code.match(
+                /global\s*=\s*\(*new\s*Function\(['"]return\s*window.top['"]\)\)*\(\)/
+            )
+        );
+    });
+
+    it('can store coverage object in alternative scope without function', function() {
+        const opts = { generateOnly: true };
+        const instrumentOpts = {
+            coverageGlobalScope: 'window.top',
+            coverageGlobalScopeFunc: false
+        };
+        const v = verifier.create('console.log("test");', opts, instrumentOpts);
+        var code;
+        assert.ok(!v.err);
+        code = v.getGeneratedCode();
+        assert.ok(code.match(/global\s*=\s*window.top;/));
+    });
 });


### PR DESCRIPTION
This new option allows modification of the function which finds the
global variable scope.  The default global scope is `this`, resulting in
`(new Function('return this))()` to retrieve the global scope.  This can
now be changed, for example `window.top` could be used to always use the
top level IFRAME in a web browser.

Fixes #199