### PR TITLE
Support Typescipt or Flow static types

### DIFF
--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -18,7 +18,8 @@ function defaultOpts() {
         produceSourceMap: false,
         ignoreClassMethods: [],
         sourceMapUrlCallback: null,
-        debug: false
+        debug: false,
+        staticType: 'flow'
     };
 }
 /**
@@ -37,6 +38,7 @@ function defaultOpts() {
  * @param {Function} [opts.sourceMapUrlCallback=null] a callback function that is called when a source map URL
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on
+ * @param {string} [opts.staticType='flow'] - one of `flow` or `typescript`
  */
 class Instrumenter {
     constructor(opts=defaultOpts()) {
@@ -80,15 +82,16 @@ class Instrumenter {
         }
         filename = filename || String(new Date().getTime()) + '.js';
         const opts = this.opts;
+
         const ast = parser.parse(code, {
             allowReturnOutsideFunction: opts.autoWrap,
             sourceType: opts.esModules ? "module" : "script",
             plugins: [
+              opts.staticType,
               'asyncGenerators',
               'dynamicImport',
               'objectRestSpread',
               'optionalCatchBinding',
-              'flow',
               'jsx'
             ]
         });

--- a/packages/istanbul-lib-instrument/test/staticType.test.js
+++ b/packages/istanbul-lib-instrument/test/staticType.test.js
@@ -1,0 +1,66 @@
+/* globals describe, it, context */
+
+import Instrumenter from '../src/instrumenter';
+import {assert} from 'chai';
+
+// The code is unsupported for typescript
+const flowCode = 'let a: ?string';
+
+// The code is unsupported for flow
+const typescriptCode = `
+  export class MyClass {
+    private readonly logger: object
+  }
+`;
+
+const generateCode = (staticType, code) => {
+  const opts = {
+      esModules: true,
+      produceSourceMap: true,
+      staticType
+  };
+  const instrumenter = new Instrumenter(opts);
+  return instrumenter.instrumentSync(code, __filename);
+};
+
+describe('staticType', function () {
+  context('option is FLOW and code style is FLOW', function() {
+    it('should success', function () {
+        const generated = generateCode('flow', flowCode);
+
+        assert.ok(generated);
+        assert.ok(typeof generated === 'string');
+      });
+  });
+
+  context('option is FLOW and code style is TYPESCRIPT', function() {
+    it('should fail', function (done) {
+      try {
+        generateCode('flow', typescriptCode);
+      } catch(e) {
+        assert.ok(e.message.includes('Unexpected token'));
+        done();
+      }
+    });
+  });
+
+  context('option is TYPESCRIPT and code style is TYPESCRIPT', function() {
+    it('should success', function () {
+        const generated = generateCode('typescript', typescriptCode);
+
+        assert.ok(generated);
+        assert.ok(typeof generated === 'string');
+    });
+  });
+
+  context('option is TYPESCRIPT and code style is FLOW', function() {
+    it('should fail', function (done) {
+        try {
+          generateCode('typescript', flowCode);
+        } catch(e) {
+          assert.ok(e.message.includes('Unexpected token'));
+          done();
+        }
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces:

Better compatibility when is instrumenting the code. Project with Typescript code has a lot of issues when flow can't instrument the code.

- Adds the option `staticType` with default value `flow`, it can be `flow` or `typescript`
- Unit test


