### PR TITLE
Add option plugins

### DIFF
--- a/packages/istanbul-lib-instrument/src/index.js
+++ b/packages/istanbul-lib-instrument/src/index.js
@@ -1,6 +1,7 @@
 import Instrumenter from './instrumenter';
 import programVisitor from './visitor';
 import readInitialCoverage from './read-coverage';
+import {defaultOpts} from './instrumenter';
 
 /**
  * createInstrumenter creates a new instrumenter with the
@@ -15,3 +16,5 @@ function createInstrumenter(opts) {
 export {createInstrumenter};
 export {programVisitor};
 export {readInitialCoverage};
+export {defaultOpts};
+

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -8,7 +8,7 @@ import traverse from '@babel/traverse';
 import generate from '@babel/generator';
 import programVisitor from './visitor';
 
-function defaultOpts() {
+export function defaultOpts() {
     return {
         coverageVariable: "__coverage__",
         preserveComments: false,
@@ -19,7 +19,14 @@ function defaultOpts() {
         ignoreClassMethods: [],
         sourceMapUrlCallback: null,
         debug: false,
-        plugins: []
+        plugins: [
+          'asyncGenerators',
+          'dynamicImport',
+          'objectRestSpread',
+          'optionalCatchBinding',
+          'flow',
+          'jsx'
+        ]
     };
 }
 /**
@@ -38,7 +45,7 @@ function defaultOpts() {
  * @param {Function} [opts.sourceMapUrlCallback=null] a callback function that is called when a source map URL
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on
- * @param {array} [opts.plugins=[]] - set plugins
+ * @param {array} [opts.plugins=['asyncGenerators','dynamicImport','objectRestSpread','optionalCatchBinding','flow','jsx']] - set plugins
  */
 class Instrumenter {
     constructor(opts=defaultOpts()) {
@@ -82,18 +89,10 @@ class Instrumenter {
         }
         filename = filename || String(new Date().getTime()) + '.js';
         const opts = this.opts;
-        const defaultPlugins = [
-          'asyncGenerators',
-          'dynamicImport',
-          'objectRestSpread',
-          'optionalCatchBinding',
-          'flow',
-          'jsx'
-        ];
         const ast = parser.parse(code, {
             allowReturnOutsideFunction: opts.autoWrap,
             sourceType: opts.esModules ? "module" : "script",
-            plugins: [...defaultPlugins, ...opts.plugins]
+            plugins: opts.plugins
         });
         const ee = programVisitor(t, filename, {
             coverageVariable: opts.coverageVariable,

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -18,7 +18,8 @@ function defaultOpts() {
         produceSourceMap: false,
         ignoreClassMethods: [],
         sourceMapUrlCallback: null,
-        debug: false
+        debug: false,
+        plugins: []
     };
 }
 /**
@@ -37,6 +38,7 @@ function defaultOpts() {
  * @param {Function} [opts.sourceMapUrlCallback=null] a callback function that is called when a source map URL
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on
+ * @param {array} [opts.plugins=[]] - set plugins
  */
 class Instrumenter {
     constructor(opts=defaultOpts()) {
@@ -80,17 +82,18 @@ class Instrumenter {
         }
         filename = filename || String(new Date().getTime()) + '.js';
         const opts = this.opts;
+        const defaultPlugins = [
+          'asyncGenerators',
+          'dynamicImport',
+          'objectRestSpread',
+          'optionalCatchBinding',
+          'flow',
+          'jsx'
+        ];
         const ast = parser.parse(code, {
             allowReturnOutsideFunction: opts.autoWrap,
             sourceType: opts.esModules ? "module" : "script",
-            plugins: [
-              'asyncGenerators',
-              'dynamicImport',
-              'objectRestSpread',
-              'optionalCatchBinding',
-              'flow',
-              'jsx'
-            ]
+            plugins: [...defaultPlugins, ...opts.plugins]
         });
         const ee = programVisitor(t, filename, {
             coverageVariable: opts.coverageVariable,

--- a/packages/istanbul-lib-instrument/test/plugins.test.js
+++ b/packages/istanbul-lib-instrument/test/plugins.test.js
@@ -1,0 +1,45 @@
+/* globals describe, it, context */
+
+import Instrumenter from '../src/instrumenter';
+import {assert} from 'chai';
+
+const codeNeedDecoratorPlugin = `
+  @decorator
+  class MyClass {}
+`;
+
+const generateCode = (staticType, code, plugins = []) => {
+  const opts = {
+      esModules: true,
+      produceSourceMap: true,
+      staticType,
+      plugins
+  };
+  const instrumenter = new Instrumenter(opts);
+  return instrumenter.instrumentSync(code, __filename);
+};
+
+describe('plugins', function () {
+  context('when the code has a decorator', function() {
+    context('without decorator plugin', function() {
+      it('should fail', function (done) {
+          try {
+            generateCode('flow', codeNeedDecoratorPlugin);
+          } catch(e) {
+            const expected =
+            `This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators'`;
+            assert.ok(e.message.includes(expected));
+            done();
+          }
+        });
+    });
+
+    context('with decorator plugin', function() {
+      it('should success', function () {
+        const generated = generateCode('flow', codeNeedDecoratorPlugin, ['decorators']);
+        assert.ok(generated);
+        assert.ok(typeof generated === 'string');
+      });
+    });
+  });
+});

--- a/packages/istanbul-lib-instrument/test/plugins.test.js
+++ b/packages/istanbul-lib-instrument/test/plugins.test.js
@@ -8,11 +8,10 @@ const codeNeedDecoratorPlugin = `
   class MyClass {}
 `;
 
-const generateCode = (staticType, code, plugins = []) => {
+const generateCode = (code, plugins) => {
   const opts = {
       esModules: true,
       produceSourceMap: true,
-      staticType,
       plugins
   };
   const instrumenter = new Instrumenter(opts);
@@ -24,7 +23,7 @@ describe('plugins', function () {
     context('without decorator plugin', function() {
       it('should fail', function (done) {
           try {
-            generateCode('flow', codeNeedDecoratorPlugin);
+            generateCode(codeNeedDecoratorPlugin);
           } catch(e) {
             const expected =
             `This experimental syntax requires enabling one of the following parser plugin(s): 'decorators-legacy, decorators'`;
@@ -36,7 +35,7 @@ describe('plugins', function () {
 
     context('with decorator plugin', function() {
       it('should success', function () {
-        const generated = generateCode('flow', codeNeedDecoratorPlugin, ['decorators']);
+        const generated = generateCode(codeNeedDecoratorPlugin, ['decorators']);
         assert.ok(generated);
         assert.ok(typeof generated === 'string');
       });


### PR DESCRIPTION
This PR introduces:

The ability to add more plugins for `@babel/parser`

- adds the option `plugins`
- unit test