### PR TITLE
Support turning off node_modules default exclude via flag

### DIFF
--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -14,7 +14,8 @@ class TestExclude {
                 relativePath: true,
                 configKey: null, // the key to load config from in package.json.
                 configPath: null, // optionally override requireMainFilename.
-                configFound: false
+                configFound: false,
+                excludeNodeModules: true
             },
             opts
         );
@@ -41,7 +42,10 @@ class TestExclude {
             this.include = false;
         }
 
-        if (!this.exclude.includes('**/node_modules/**')) {
+        if (
+            this.excludeNodeModules &&
+            !this.exclude.includes('**/node_modules/**')
+        ) {
             this.exclude.push('**/node_modules/**');
         }
 

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -131,6 +131,25 @@ describe('testExclude', function() {
         e.shouldInstrument('src/foo.js').should.equal(true);
     });
 
+    it('allows node_modules default exclusion glob to be turned off, if excludeNodeModules === false', function() {
+        const e = exclude({
+            excludeNodeModules: false,
+            exclude: ['node_modules/**', '**/__test__/**']
+        });
+
+        e.shouldInstrument('node_modules/cat.js').should.equal(false);
+        e.shouldInstrument('./banana/node_modules/cat.js').should.equal(true);
+        e.shouldInstrument(
+            './banana/node_modules/__test__/cat.test.js'
+        ).should.equal(false);
+        e.shouldInstrument(
+            './banana/node_modules/__test__/cat-test.js'
+        ).should.equal(false);
+        e.shouldInstrument(
+            './banana/node_modules/__test__/cat.js'
+        ).should.equal(false);
+    });
+
     it('allows negated exclude patterns', function() {
         const e = exclude({
             exclude: ['foo/**', '!foo/bar.js']


### PR DESCRIPTION
This PR is the first step at resolving [NYC's issue #898](https://github.com/istanbuljs/nyc/issues/898) I raised. The idea is to be able to turn off the default exclusion of `**/node_modules/**` for users that need/want to support local `node_modules`. As mentioned in that issue, the `negateExclude` (i.e. `!**/node_modules/**`) doesn't work for cases when you still want your exclusion list to still exclude matches within your local `node_modules` directory. 

Related PRs for solving the above issue:
- https://github.com/istanbuljs/nyc/pull/912
- https://github.com/istanbuljs/babel-plugin-istanbul/pull/172

**NOTE:** Not sure if you also would want the `exportFunc.defaultExclude` list to take into account this option. For now, I'm not touching that so for this flag to work, at least one `exclude` must be present. Let me know if you would want this to also be included and I can make that edit. Thanks!