### PR TITLE
fix: Tweak package.json files for republish as latest 1.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ env:
 
 before_install:
   - npm cache clear --force
-  - npm i npm@latest -g
 
 after_success: nyc report --reporter=text-lcov | coveralls

--- a/packages/istanbul-api/package.json
+++ b/packages/istanbul-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-api",
-  "version": "1.2.2",
+  "version": "1.3.6",
   "description": "High level API for istanbul features",
   "main": "index.js",
   "files": [
@@ -37,12 +37,12 @@
   "dependencies": {
     "async": "^2.1.4",
     "fileset": "^2.0.2",
-    "istanbul-lib-coverage": "^1.1.2",
-    "istanbul-lib-hook": "^1.1.0",
-    "istanbul-lib-instrument": "^1.9.2",
-    "istanbul-lib-report": "^1.1.3",
-    "istanbul-lib-source-maps": "^1.2.3",
-    "istanbul-reports": "^1.1.4",
+    "istanbul-lib-coverage": "^1.2.0",
+    "istanbul-lib-hook": "^1.2.1",
+    "istanbul-lib-instrument": "^1.10.1",
+    "istanbul-lib-report": "^1.1.4",
+    "istanbul-lib-source-maps": "^1.2.5",
+    "istanbul-reports": "^1.5.0",
     "js-yaml": "^3.7.0",
     "mkdirp": "^0.5.1",
     "once": "^1.4.0"

--- a/packages/istanbul-lib-coverage/package.json
+++ b/packages/istanbul-lib-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-coverage",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Data library for istanbul coverage objects",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "index.js",

--- a/packages/istanbul-lib-hook/package.json
+++ b/packages/istanbul-lib-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-hook",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Hooks for require, vm and script used in istanbul",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "index.js",

--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-instrument",
-  "version": "1.9.2",
+  "version": "1.10.1",
   "description": "Core istanbul API for JS code coverage",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "babel-traverse": "^6.18.0",
     "babel-types": "^6.18.0",
     "babylon": "^6.18.0",
-    "istanbul-lib-coverage": "^1.1.2",
+    "istanbul-lib-coverage": "^1.2.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-report",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Base reporting library for istanbul",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "index.js",
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "istanbul-lib-coverage": "^1.1.2",
+    "istanbul-lib-coverage": "^1.2.0",
     "mkdirp": "^0.5.1",
     "path-parse": "^1.0.5",
     "supports-color": "^3.1.2"

--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-source-maps",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Source maps support for istanbul",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "index.js",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
-    "istanbul-lib-coverage": "^1.1.2",
+    "istanbul-lib-coverage": "^1.2.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",
     "source-map": "^0.5.3"

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-reports",
-  "version": "1.1.4",
+  "version": "1.5.0",
   "description": "istanbul reports",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "index.js",
@@ -18,8 +18,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "is-windows": "^1.0.1",
-    "istanbul-lib-coverage": "^1.1.2",
-    "istanbul-lib-report": "^1.1.3",
+    "istanbul-lib-coverage": "^1.2.0",
+    "istanbul-lib-report": "^1.1.4",
     "jshint": "^2.8.0",
     "mocha": "^3.1.2"
   },

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-exclude",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "description": "test for inclusion or exclusion of paths using pkg-conf and globs",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Breaking changes leaked into 1.x modules but it was thought they were
never released to latest.  Apparently releasing 2.x to latest makes
those unwanted versions of 1.x available.

This patch sets all modules to the latest 1.x version (4.x for
test-exclude).  This will allow a new release to be made to revert
release of the breaking changes.

Fixes #216