### PR TITLE
chore: Update test for babel 7.

### DIFF
--- a/packages/istanbul-lib-instrument/api.md
+++ b/packages/istanbul-lib-instrument/api.md
@@ -40,6 +40,7 @@ instead.
     -   `opts.sourceMapUrlCallback` **[Function][12]** a callback function that is called when a source map URL
             is found in the original code. This function is called with the source file name and the source map URL. (optional, default `null`)
     -   `opts.debug` **[boolean][10]** turn debugging on (optional, default `false`)
+    -   `opts.plugins` **[array][11]** set plugins (optional, default `['asyncGenerators','dynamicImport','objectRestSpread','optionalCatchBinding','flow','jsx']`)
 
 ### instrumentSync
 

--- a/packages/istanbul-lib-instrument/test/plugins.test.js
+++ b/packages/istanbul-lib-instrument/test/plugins.test.js
@@ -35,7 +35,7 @@ describe('plugins', function () {
 
     context('with decorator plugin', function() {
       it('should success', function () {
-        const generated = generateCode(codeNeedDecoratorPlugin, ['decorators']);
+        const generated = generateCode(codeNeedDecoratorPlugin, [['decorators', {decoratorsBeforeExport: false}]]);
         assert.ok(generated);
         assert.ok(typeof generated === 'string');
       });


### PR DESCRIPTION
PR #205 was only tested against babel 7.0.0-beta.51, it appears a
breaking change was added which requires an option for the `decorators`
plugin.  Add it to get tests working again, commit updated api.md.