### PR TITLE
fix: clover report metrics must be an inline xml element (#13)

### DIFF
--- a/packages/istanbul-reports/lib/clover/index.js
+++ b/packages/istanbul-reports/lib/clover/index.js
@@ -88,7 +88,7 @@ CloverReport.prototype.writeRootStats = function (node, context) {
         attrs[k] = treeStats[k];
     });
 
-    this.xml.openTag('metrics', attrs);
+    this.xml.inlineTag('metrics', attrs);
 
 };
 


### PR DESCRIPTION
fix: clover report metrics must be an inline xml element see https://bitbucket.org/atlassian/clover/src/default/etc/schema/clover.xsd (#13)