### PR TITLE
Fix for nested strategy when no files

### DIFF
--- a/packages/istanbul-lib-report/lib/summarizer.js
+++ b/packages/istanbul-lib-report/lib/summarizer.js
@@ -232,7 +232,7 @@ function createNestedSummary(coverageMap) {
         root;
 
     if (topNodes.length === 0) {
-        return treeFor(new ReportNode([]));
+        return treeFor(new ReportNode(new Path([])));
     }
 
     if (topNodes.length === 1) {

--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -321,7 +321,15 @@ describe('summarizer', function() {
             assert.deepEqual(nodes, ['g:']);
         });
 
-        it('supports a list of files at top-level', function() {
+        it('handles getting root node name when empty coverage map', function() {
+          var map = coverage.createCoverageMap({}),
+              tree = fn(map),
+              root = tree.getRoot(),
+              rootNodeName = root.getRelativeName();
+          assert.equal(rootNodeName, '');
+        });
+
+        it('supports a list of files at top-level', function () {
             var map = singleDirMap(),
                 tree = fn(map),
                 nodes = getStructure(tree);

--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -321,7 +321,7 @@ describe('summarizer', function() {
             assert.deepEqual(nodes, ['g:']);
         });
 
-        it('handles getting root node name when empty coverage map', function() {
+        it('handles getting root node name without crashing when empty coverage map', function() {
             var map = coverage.createCoverageMap({}),
                 tree = fn(map),
                 root = tree.getRoot(),

--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -322,14 +322,14 @@ describe('summarizer', function() {
         });
 
         it('handles getting root node name when empty coverage map', function() {
-          var map = coverage.createCoverageMap({}),
-              tree = fn(map),
-              root = tree.getRoot(),
-              rootNodeName = root.getRelativeName();
-          assert.equal(rootNodeName, '');
+            var map = coverage.createCoverageMap({}),
+                tree = fn(map),
+                root = tree.getRoot(),
+                rootNodeName = root.getRelativeName();
+            assert.equal(rootNodeName, '');
         });
 
-        it('supports a list of files at top-level', function () {
+        it('supports a list of files at top-level', function() {
             var map = singleDirMap(),
                 tree = fn(map),
                 nodes = getStructure(tree);


### PR DESCRIPTION
This fixes an issue I was experiencing when using the nested summarizer and the coverage map had no files.

Previously it would throw an error
```
TypeError: other.contains is not a function
at Path.ancestorOf (/Users/heatherroberts/Desktop/Test Projects/jest/node_modules/istanbul-lib-report/lib/path.js:97:18)
```
