### PR TITLE
bug fix for #224: failed to write coverage report (lcovonly)

### DIFF
--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -27,14 +27,14 @@ LcovOnlyReport.prototype.onDetail = function (node) {
     writer.println('TN:'); //no test name
     writer.println('SF:' + fc.path);
 
-    Object.keys(functions).forEach(function (key) {
+    Object.keys(functionMap).forEach(function (key) {
         var meta = functionMap[key];
         writer.println('FN:' + [meta.decl.start.line, meta.name].join(','));
     });
     writer.println('FNF:' + summary.functions.total);
     writer.println('FNH:' + summary.functions.covered);
 
-    Object.keys(functions).forEach(function (key) {
+    Object.keys(functionMap).forEach(function (key) {
         var stats = functions[key],
             meta = functionMap[key];
         writer.println('FNDA:' + [stats, meta.name].join(','));


### PR DESCRIPTION
Replace `Object.keys(functions)` by `Object.keys(functionMap)` since inside of the loop `functionMap[key]` is used for lookup.

This is also the same behaviour as for the `cobertura` reporter here: https://github.com/istanbuljs/istanbuljs/blob/2857f990a85c9f276ec96f0e6969a33577be4ea7/packages/istanbul-reports/lib/cobertura/index.js#L98-L109
`Object.keys(fnMap)` is used for iteration and then `fnMap[k].decl.start.line` is used for accessing the data.

see: https://github.com/istanbuljs/istanbuljs/issues/224