### PR TITLE
fix: correctly calculate end position of sourcemap statement

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -14,23 +14,87 @@ function isInvalidPosition (pos) {
 }
 
 /**
+ * AST ranges are inclusive for start positions and exclusive for end positions.
+ * Source maps are also logically ranges over text, though interacting with
+ * them is generally achieved by working with explicit positions.
+ *
+ * When finding the _end_ location of an AST item, the range behavior is
+ * important because what we're asking for is the _end_ of whatever range
+ * corresponds to the end location we seek.
+ *
+ * This boils down to the following steps, conceptually, though the source-map
+ * library doesn't expose primitives to do this nicely:
+ *
+ * 1. Find the range on the generated file that ends at, or exclusively
+ *    contains the end position of the AST node.
+ * 2. Find the range on the original file that corresponds to
+ *    that generated range.
+ * 3. Find the _end_ location of that original range.
+ */
+function originalEndPositionFor(sourceMap, generatedEnd) {
+    // Given the generated location, find the original location of the mapping
+    // that corresponds to a range on the generated file that overlaps the
+    // generated file end location. Note however that this position on its
+    // own is not useful because it is the position of the _start_ of the range
+    // on the original file, and we want the _end_ of the range.
+    var beforeEndMapping = sourceMap.originalPositionFor({
+        line: generatedEnd.line,
+        column: generatedEnd.column - 1,
+    });
+    if (beforeEndMapping.source === null) {
+        return null;
+    }
+
+    // Convert that original position back to a generated one, with a bump
+    // to the right, and a rightward bias. Since 'generatedPositionFor' searches
+    // for mappings in the original-order sorted list, this will find the
+    // mapping that corresponds to the one immediately after the
+    // beforeEndMapping mapping.
+    var afterEndMapping = sourceMap.generatedPositionFor({
+        source: beforeEndMapping.source,
+        line: beforeEndMapping.line,
+        column: beforeEndMapping.column + 1,
+        bias: 2
+    });
+    if (
+        // If this is null, it means that we've hit the end of the file,
+        // so we can use Infinity as the end column.
+        afterEndMapping.line === null ||
+
+        // If these don't match, it means that the call to
+        // 'generatedPositionFor' didn't find any other original mappings on
+        // the line we gave, so consider the binding to extend to infinity.
+        sourceMap.originalPositionFor(afterEndMapping).line !== beforeEndMapping.line
+    ) {
+        return {
+            source: beforeEndMapping.source,
+            line: beforeEndMapping.line,
+            column: Infinity,
+        };
+    }
+
+    // Convert the end mapping into the real original position.
+    return sourceMap.originalPositionFor(afterEndMapping);
+}
+
+/**
  * determines the original position for a given location
  * @param  {SourceMapConsumer} sourceMap the source map
- * @param  {Object} location the original location Object
+ * @param  {Object} generatedLocation the original location Object
  * @returns {Object} the remapped location Object
  */
-function getMapping(sourceMap, location, origFile) {
+function getMapping(sourceMap, generatedLocation, origFile) {
 
-    if (!location) {
+    if (!generatedLocation) {
         return null;
     }
 
-    if (isInvalidPosition(location.start) || isInvalidPosition(location.end)) {
+    if (isInvalidPosition(generatedLocation.start) || isInvalidPosition(generatedLocation.end)) {
         return null;
     }
 
-    var start = sourceMap.originalPositionFor(location.start),
-        end = sourceMap.originalPositionFor(location.end);
+    var start = sourceMap.originalPositionFor(generatedLocation.start),
+        end = originalEndPositionFor(sourceMap, generatedLocation.end);
 
     /* istanbul ignore if: edge case too hard to test for */
     if (!(start && end)) {


### PR DESCRIPTION
This is copy-paste from https://github.com/facebook/jest/pull/7202#issuecomment-441467894
All credit goes to @loganfsmyth!

Not sure how to add a test? I copied this into my `node_modules`, and it fixed the bug in Jest at least 🙂 