### PR TITLE
 fix: pull in @loganfsmyth's SourceMap fixes

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -14,23 +14,87 @@ function isInvalidPosition (pos) {
 }
 
 /**
+ * AST ranges are inclusive for start positions and exclusive for end positions.
+ * Source maps are also logically ranges over text, though interacting with
+ * them is generally achieved by working with explicit positions.
+ *
+ * When finding the _end_ location of an AST item, the range behavior is
+ * important because what we're asking for is the _end_ of whatever range
+ * corresponds to the end location we seek.
+ *
+ * This boils down to the following steps, conceptually, though the source-map
+ * library doesn't expose primitives to do this nicely:
+ *
+ * 1. Find the range on the generated file that ends at, or exclusively
+ *    contains the end position of the AST node.
+ * 2. Find the range on the original file that corresponds to
+ *    that generated range.
+ * 3. Find the _end_ location of that original range.
+ */
+function originalEndPositionFor(sourceMap, generatedEnd) {
+    // Given the generated location, find the original location of the mapping
+    // that corresponds to a range on the generated file that overlaps the
+    // generated file end location. Note however that this position on its
+    // own is not useful because it is the position of the _start_ of the range
+    // on the original file, and we want the _end_ of the range.
+    var beforeEndMapping = sourceMap.originalPositionFor({
+        line: generatedEnd.line,
+        column: generatedEnd.column - 1,
+    });
+    if (beforeEndMapping.source === null) {
+        return null;
+    }
+
+    // Convert that original position back to a generated one, with a bump
+    // to the right, and a rightward bias. Since 'generatedPositionFor' searches
+    // for mappings in the original-order sorted list, this will find the
+    // mapping that corresponds to the one immediately after the
+    // beforeEndMapping mapping.
+    var afterEndMapping = sourceMap.generatedPositionFor({
+        source: beforeEndMapping.source,
+        line: beforeEndMapping.line,
+        column: beforeEndMapping.column + 1,
+        bias: 2
+    });
+    if (
+        // If this is null, it means that we've hit the end of the file,
+        // so we can use Infinity as the end column.
+        afterEndMapping.line === null ||
+
+        // If these don't match, it means that the call to
+        // 'generatedPositionFor' didn't find any other original mappings on
+        // the line we gave, so consider the binding to extend to infinity.
+        sourceMap.originalPositionFor(afterEndMapping).line !== beforeEndMapping.line
+    ) {
+        return {
+            source: beforeEndMapping.source,
+            line: beforeEndMapping.line,
+            column: Infinity,
+        };
+    }
+
+    // Convert the end mapping into the real original position.
+    return sourceMap.originalPositionFor(afterEndMapping);
+}
+
+/**
  * determines the original position for a given location
  * @param  {SourceMapConsumer} sourceMap the source map
- * @param  {Object} location the original location Object
+ * @param  {Object} generatedLocation the original location Object
  * @returns {Object} the remapped location Object
  */
-function getMapping(sourceMap, location, origFile) {
+function getMapping(sourceMap, generatedLocation, origFile) {
 
-    if (!location) {
+    if (!generatedLocation) {
         return null;
     }
 
-    if (isInvalidPosition(location.start) || isInvalidPosition(location.end)) {
+    if (isInvalidPosition(generatedLocation.start) || isInvalidPosition(generatedLocation.end)) {
         return null;
     }
 
-    var start = sourceMap.originalPositionFor(location.start),
-        end = sourceMap.originalPositionFor(location.end);
+    var start = sourceMap.originalPositionFor(generatedLocation.start),
+        end = originalEndPositionFor(sourceMap, generatedLocation.end);
 
     /* istanbul ignore if: edge case too hard to test for */
     if (!(start && end)) {

--- a/packages/istanbul-lib-source-maps/test/map-store.test.js
+++ b/packages/istanbul-lib-source-maps/test/map-store.test.js
@@ -25,8 +25,8 @@ describe('map store', function () {
           "column": 0
         },
         "end": {
-          "line": 5,
-          "column": 0
+          "line": 1,
+          "column": 13
         }
       },
       "1": {
@@ -36,7 +36,7 @@ describe('map store', function () {
         },
         "end": {
           "line": 4,
-          "column": 5
+          "column": Infinity
         }
       },
       "2": {
@@ -56,12 +56,12 @@ describe('map store', function () {
         },
         "end": {
           "line": 5,
-          "column": 1
+          "column": Infinity
         }
       },
       "4": {
         "end": {
-          "column": 1,
+          "column": Infinity,
           "line": 5
         },
         "start": {
@@ -79,8 +79,8 @@ describe('map store', function () {
             "column": 0
           },
           "end": {
-            "line": null,
-            "column": -1
+            "line": 1,
+            "column": 13
           }
         },
         "loc": {
@@ -89,8 +89,8 @@ describe('map store', function () {
             "column": 0
           },
           "end": {
-            "line": 1,
-            "column": -1
+            "line": 5,
+            "column": Infinity
           }
         }
       },
@@ -102,8 +102,8 @@ describe('map store', function () {
             "column": 4
           },
           "end": {
-            "line": null,
-            "column": -1
+            "line": 2,
+            "column": 6
           }
         },
         "loc": {


### PR DESCRIPTION
This pulls in @loganfsmyth's modifications to the remapping algorithm for SourceMaps.

I have a couple questions that I've left inline, please note that the tests that need to be modified reference the following:

```js
  // Original source
  // export class SimpleClass {
  //     hy() {
  //         console.log("Hy");
  //     }
  // }
  // Transpiled Source
  // "use strict";
  // var SimpleClass = (function () {
  //     function SimpleClass() {
  //     }
  //     SimpleClass.prototype.hy = function () {
  //         console.log("Hy");
  //     };
  //     return SimpleClass;
  // }());
  // exports.SimpleClass = SimpleClass;
```

CC: @loganfsmyth, @SimenB 