### PR TITLE
fix: correct variable name in source-map transform

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -118,8 +118,8 @@ function getMapping(sourceMap, generatedLocation, origFile) {
 
     if (start.line === end.line && start.column === end.column) {
         end = sourceMap.originalPositionFor({
-            line: location.end.line,
-            column: location.end.column,
+            line: generatedLocation.end.line,
+            column: generatedLocation.end.column,
             bias: 2
         });
         end.column = end.column - 1;


### PR DESCRIPTION
A linter should probably have caught this