### PR TITLE
Suggestion: Enable keyboard shortcuts on HTML report file listing view

### DIFF
--- a/packages/istanbul-reports/lib/html/assets/block-navigation.js
+++ b/packages/istanbul-reports/lib/html/assets/block-navigation.js
@@ -10,8 +10,10 @@ var jumpToCode = (function init() {
 
     // Selecter that finds elements on the page to which we can jump
     var selector =
-        fileListingElements.join(', ') + ', ' +
-        notSelector + missingCoverageClasses.join(', ' + notSelector); // becomes `:not(a):not(b) > a, :not(a):not(b) > b`
+        fileListingElements.join(', ') +
+        ', ' +
+        notSelector +
+        missingCoverageClasses.join(', ' + notSelector); // becomes `:not(a):not(b) > a, :not(a):not(b) > b`
 
     // The NodeList of matching elements
     var missingCoverageElements = document.querySelectorAll(selector);

--- a/packages/istanbul-reports/lib/html/assets/block-navigation.js
+++ b/packages/istanbul-reports/lib/html/assets/block-navigation.js
@@ -1,12 +1,16 @@
 var jumpToCode = (function init() {
-    // Classes of code we would like to highlight
+    // Classes of code we would like to highlight in the file view
     var missingCoverageClasses = ['.cbranch-no', '.cstat-no', '.fstat-no'];
+
+    // Elements to highlight in the file listing view
+    var fileListingElements = ['td.pct.low'];
 
     // We don't want to select elements that are direct descendants of another match
     var notSelector = ':not(' + missingCoverageClasses.join('):not(') + ') > '; // becomes `:not(a):not(b) > `
 
     // Selecter that finds elements on the page to which we can jump
     var selector =
+        fileListingElements.join(', ') + ', ' +
         notSelector + missingCoverageClasses.join(', ' + notSelector); // becomes `:not(a):not(b) > a, :not(a):not(b) > b`
 
     // The NodeList of matching elements


### PR DESCRIPTION
### GOAL

When looking at the file listing view of an HTML code coverage report, allow the usual keyboard shortcuts to cycle through low coverage metrics (highlighting the particular statement/branch/lines etc. cell that has low coverage).

### DETAILS

This change is most useful for code coverage reports with hundreds or thousands of files in a listing.  Similar to how just tapping `n` is useful for jumping to the first issue in a large code file, being able to tap `n` and jump to the first file with low/missing coverage might also be helpful.

(Functionally, it's probably just as easy and more flexible to click Sort on the file column header, but this is an easy change and seems consistent.)

### TESTS

No unit tests changed or added.  Tested locally in Chrome, Firefox and Safari.
