### PR TITLE
chore: prettierignore files modified on release

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 **/CHANGELOG.md
-package*.json
+**/package*.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+**/CHANGELOG.md
+package*.json


### PR DESCRIPTION
Something we forgot in #261 was to make sure our automated tools (semantic-version etc) don't get messed with by prettier on release