### PR TITLE
Map unique files once, regardless of path separator

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -234,12 +234,17 @@ SourceMapTransformer.prototype.processFile = function(
 SourceMapTransformer.prototype.transform = function(coverageMap) {
     var that = this,
         finder = this.finder,
-        output = {},
+        uniqueFiles = {},
+        key,
         getMappedCoverage = function(file) {
-            if (!output[file]) {
-                output[file] = new MappedCoverage(file);
+            key = getUniqueKey(file);
+            if (!uniqueFiles[key]) {
+                uniqueFiles[key] = {
+                    file: file,
+                    mappedCoverage: new MappedCoverage(file)
+                };
             }
-            return output[file];
+            return uniqueFiles[key].mappedCoverage;
         };
 
     coverageMap.files().forEach(function(file) {
@@ -248,7 +253,10 @@ SourceMapTransformer.prototype.transform = function(coverageMap) {
             changed;
 
         if (!sourceMap) {
-            output[file] = fc;
+            uniqueFiles[getUniqueKey(file)] = {
+                file: file,
+                mappedCoverage: fc
+            };
             return;
         }
 
@@ -257,8 +265,22 @@ SourceMapTransformer.prototype.transform = function(coverageMap) {
             debug('File [' + file + '] ignored, nothing could be mapped');
         }
     });
-    return libCoverage.createCoverageMap(output);
+    return libCoverage.createCoverageMap(getOutput(uniqueFiles));
 };
+
+function getUniqueKey(path) {
+    return path.replace(/[\\/]/g, '_');
+}
+
+function getOutput(cache) {
+    var output = {},
+        item;
+    Object.keys(cache).forEach(function(key) {
+        item = cache[key];
+        output[item.file] = item.mappedCoverage;
+    });
+    return output;
+}
 
 module.exports = {
     create: function(finder, opts) {

--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -273,13 +273,12 @@ function getUniqueKey(path) {
 }
 
 function getOutput(cache) {
-    var output = {},
-        item;
-    Object.keys(cache).forEach(function(key) {
-        item = cache[key];
-        output[item.file] = item.mappedCoverage;
-    });
-    return output;
+    return Object.keys(cache).reduce((output, key) => {
+        const item = cache[key];
+        return Object.assign(output, {
+            [item.file]: item.mappedCoverage
+        });
+    }, {});
 }
 
 module.exports = {

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -3,17 +3,8 @@ var assert = require('chai').assert,
     isWindows = require('is-windows'),
     createMap = require('istanbul-lib-coverage').createCoverageMap,
     SMC = require('source-map').SourceMapConsumer,
-    createTransformer = require('../lib/transformer').create;
-
-function createData() {
-    var sourceMap = {
-        version: 3,
-        sources: ['file.js'],
-        mappings: ';AAAa,mBAAW,GAAG,MAAM,CAAC;AACrB,kBAAU,GAAG,yBAAyB,CAAC'
-    };
-
-    var coverageData = {
-        path: '/path/to/file.js',
+    createTransformer = require('../lib/transformer').create,
+    coverageData = {
         statementMap: {
             '0': {
                 start: { line: 2, column: 0 },
@@ -35,38 +26,24 @@ function createData() {
         b: {}
     };
 
+function createData() {
+    var data = Object.assign({}, coverageData);
+    data.path = '/path/to/file.js';
     return {
-        sourceMap: sourceMap,
-        coverageData: coverageData
+        sourceMap: {
+            version: 3,
+            sources: ['file.js'],
+            mappings: ';AAAa,mBAAW,GAAG,MAAM,CAAC;AACrB,kBAAU,GAAG,yBAAyB,CAAC'
+        },
+        coverageData: data
     };
 }
 
 function createDataBackslash() {
-    var coverageData = {
-        path: '\\path\\to\\file.js',
-        statementMap: {
-            '0': {
-                start: { line: 2, column: 0 },
-                end: { line: 2, column: 29 }
-            },
-            '1': {
-                start: { line: 3, column: 0 },
-                end: { line: 3, column: 47 }
-            }
-        },
-        fnMap: {},
-        branchMap: {},
-        s: {
-            '0': 0,
-            '1': 0,
-            '2': 0
-        },
-        f: {},
-        b: {}
-    };
-
+    var data = Object.assign({}, coverageData);
+    data.path = '\\path\\to\\file.js';
     return {
-        coverageData: coverageData
+        coverageData: data
     };
 }
 

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -72,6 +72,10 @@ function createDataBackslash() {
 
 describe('transformer', function() {
     it('maps statement locations', function() {
+        if (isWindows()) {
+            return this.skip();
+        }
+
         var coverageMap = createMap({}),
             testData = createData(),
             coverageData = testData.coverageData,

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
+const path = require('path');
 const assert = require('chai').assert;
-const isWindows = require('is-windows');
 const createMap = require('istanbul-lib-coverage').createCoverageMap;
 const SMC = require('source-map').SourceMapConsumer;
 const createTransformer = require('../lib/transformer').create;
@@ -27,29 +27,33 @@ const coverageData = {
     b: {}
 };
 
+const sourceFileSlash = path
+    .join(__dirname, 'path/to/file.js')
+    .replace(/\\/g, '/');
+
+const sourceFileBackslash = path
+    .join(__dirname, 'path\\to\\file.js')
+    .replace(/\//g, '\\');
+
 const testDataSlash = {
     sourceMap: {
         version: 3,
-        sources: ['file.js'],
+        sources: [sourceFileSlash],
         mappings: ';AAAa,mBAAW,GAAG,MAAM,CAAC;AACrB,kBAAU,GAAG,yBAAyB,CAAC'
     },
     coverageData: Object.assign({}, coverageData, {
-        path: '/path/to/file.js'
+        path: sourceFileSlash
     })
 };
 
 const testDataBackslash = {
     coverageData: Object.assign({}, coverageData, {
-        path: '\\path\\to\\file.js'
+        path: sourceFileBackslash
     })
 };
 
 describe('transformer', function() {
     it('maps statement locations', function() {
-        if (isWindows()) {
-            return this.skip();
-        }
-
         const coverageMap = createMap({});
         coverageMap.addFileCoverage(testDataSlash.coverageData);
 
@@ -73,10 +77,6 @@ describe('transformer', function() {
     });
 
     it('maps each file only once, /path/to/file.js and \\path\\to\\file.js are the same file', function() {
-        if (isWindows()) {
-            return this.skip();
-        }
-
         const coverageMap = createMap({});
 
         coverageMap.addFileCoverage(testDataSlash.coverageData);

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -16,24 +16,12 @@ function createData() {
         path: '/path/to/file.js',
         statementMap: {
             '0': {
-                start: {
-                    line: 2,
-                    column: 0
-                },
-                end: {
-                    line: 2,
-                    column: 29
-                }
+                start: { line: 2, column: 0 },
+                end: { line: 2, column: 29 }
             },
             '1': {
-                start: {
-                    line: 3,
-                    column: 0
-                },
-                end: {
-                    line: 3,
-                    column: 47
-                }
+                start: { line: 3, column: 0 },
+                end: { line: 3, column: 47 }
             }
         },
         fnMap: {},
@@ -49,6 +37,35 @@ function createData() {
 
     return {
         sourceMap: sourceMap,
+        coverageData: coverageData
+    };
+}
+
+function createDataBackslash() {
+    var coverageData = {
+        path: '\\path\\to\\file.js',
+        statementMap: {
+            '0': {
+                start: { line: 2, column: 0 },
+                end: { line: 2, column: 29 }
+            },
+            '1': {
+                start: { line: 3, column: 0 },
+                end: { line: 3, column: 47 }
+            }
+        },
+        fnMap: {},
+        branchMap: {},
+        s: {
+            '0': 0,
+            '1': 0,
+            '2': 0
+        },
+        f: {},
+        b: {}
+    };
+
+    return {
         coverageData: coverageData
     };
 }
@@ -79,5 +96,30 @@ describe('transformer', function() {
                 end: { line: 2, column: 52 }
             }
         });
+    });
+
+    it('maps each file only once, /path/to/file.js and \\path\\to\\file.js are the same file', function() {
+        if (isWindows()) {
+            return this.skip();
+        }
+
+        var coverageMap = createMap({}),
+            testDataSlash = createData(),
+            testDataBackslash = createDataBackslash(),
+            coverageDataSlash = testDataSlash.coverageData,
+            coverageDataBackslash = testDataBackslash.coverageData,
+            sourceMap = testDataSlash.sourceMap;
+
+        coverageMap.addFileCoverage(coverageDataSlash);
+        coverageMap.addFileCoverage(coverageDataBackslash);
+
+        var mapped = createTransformer(function(file) {
+            return file === coverageDataSlash.path
+                ? new SMC(sourceMap)
+                : undefined;
+        }).transform(coverageMap);
+
+        assert.equal(Object.keys(mapped.data).length, 1);
+        assert.isDefined(mapped.data[coverageDataBackslash.path]);
     });
 });

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -1,30 +1,30 @@
 /* globals describe, it */
-var assert = require('chai').assert,
-    isWindows = require('is-windows'),
-    createMap = require('istanbul-lib-coverage').createCoverageMap,
-    SMC = require('source-map').SourceMapConsumer,
-    createTransformer = require('../lib/transformer').create,
-    coverageData = {
-        statementMap: {
-            '0': {
-                start: { line: 2, column: 0 },
-                end: { line: 2, column: 29 }
-            },
-            '1': {
-                start: { line: 3, column: 0 },
-                end: { line: 3, column: 47 }
-            }
+const assert = require('chai').assert;
+const isWindows = require('is-windows');
+const createMap = require('istanbul-lib-coverage').createCoverageMap;
+const SMC = require('source-map').SourceMapConsumer;
+const createTransformer = require('../lib/transformer').create;
+const coverageData = {
+    statementMap: {
+        '0': {
+            start: { line: 2, column: 0 },
+            end: { line: 2, column: 29 }
         },
-        fnMap: {},
-        branchMap: {},
-        s: {
-            '0': 0,
-            '1': 0,
-            '2': 0
-        },
-        f: {},
-        b: {}
-    };
+        '1': {
+            start: { line: 3, column: 0 },
+            end: { line: 3, column: 47 }
+        }
+    },
+    fnMap: {},
+    branchMap: {},
+    s: {
+        '0': 0,
+        '1': 0,
+        '2': 0
+    },
+    f: {},
+    b: {}
+};
 
 function createData() {
     var data = Object.assign({}, coverageData);
@@ -53,13 +53,13 @@ describe('transformer', function() {
             return this.skip();
         }
 
-        var coverageMap = createMap({}),
-            testData = createData(),
-            coverageData = testData.coverageData,
-            sourceMap = testData.sourceMap;
+        const coverageMap = createMap({});
+        const testData = createData();
+        const coverageData = testData.coverageData;
+        const sourceMap = testData.sourceMap;
 
         coverageMap.addFileCoverage(coverageData);
-        var mapped = createTransformer(function() {
+        const mapped = createTransformer(function() {
             return new SMC(sourceMap);
         }).transform(coverageMap);
 
@@ -80,17 +80,17 @@ describe('transformer', function() {
             return this.skip();
         }
 
-        var coverageMap = createMap({}),
-            testDataSlash = createData(),
-            testDataBackslash = createDataBackslash(),
-            coverageDataSlash = testDataSlash.coverageData,
-            coverageDataBackslash = testDataBackslash.coverageData,
-            sourceMap = testDataSlash.sourceMap;
+        const coverageMap = createMap({});
+        const testDataSlash = createData();
+        const testDataBackslash = createDataBackslash();
+        const coverageDataSlash = testDataSlash.coverageData;
+        const coverageDataBackslash = testDataBackslash.coverageData;
+        const sourceMap = testDataSlash.sourceMap;
 
         coverageMap.addFileCoverage(coverageDataSlash);
         coverageMap.addFileCoverage(coverageDataBackslash);
 
-        var mapped = createTransformer(function(file) {
+        const mapped = createTransformer(function(file) {
             return file === coverageDataSlash.path
                 ? new SMC(sourceMap)
                 : undefined;

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -72,10 +72,6 @@ function createDataBackslash() {
 
 describe('transformer', function() {
     it('maps statement locations', function() {
-        if (isWindows()) {
-            return this.skip();
-        }
-
         var coverageMap = createMap({}),
             testData = createData(),
             coverageData = testData.coverageData,

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -27,13 +27,8 @@ const coverageData = {
     b: {}
 };
 
-const sourceFileSlash = path
-    .join(__dirname, 'path/to/file.js')
-    .replace(/\\/g, '/');
-
-const sourceFileBackslash = path
-    .join(__dirname, 'path\\to\\file.js')
-    .replace(/\//g, '\\');
+const sourceFileSlash = path.posix.normalize('/path/to/file.js');
+const sourceFileBackslash = path.win32.normalize('/path/to/file.js');
 
 const testDataSlash = {
     sourceMap: {


### PR DESCRIPTION
The paths "/path/to/file.js" and "\path\to\file.js" points to the same file on Windows, this PR makes `istanbuljs` treat them as one file by using `_path_to_file.js` as a key internally when transforming coverage maps.

Long story short, this makes `istanbuljs` behave well without reporting duplicates, regardless of input.