### PR TITLE
fixed: handlebars dep bases on vulnerable version

### DIFF
--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -12,7 +12,7 @@
     "test": "mocha --recursive"
   },
   "dependencies": {
-    "handlebars": "^4.0.11"
+    "handlebars": "^4.0.13"
   },
   "devDependencies": {
     "istanbul-lib-coverage": "^2.0.3",


### PR DESCRIPTION
See https://nodesecurity.io/advisories/755