### PR TITLE
chore: Update homepage link in package.json files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://istanbul.js.org/",
+  "homepage": "https://github.com/istanbuljs/istanbuljs",
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/packages/istanbul-api/package.json
+++ b/packages/istanbul-api/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "dependencies": {
     "async": "^2.6.1",
     "compare-versions": "^3.2.1",

--- a/packages/istanbul-lib-coverage/package.json
+++ b/packages/istanbul-lib-coverage/package.json
@@ -34,7 +34,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs",
+  "homepage": "https://istanbul.js.org/",
   "engines": {
     "node": ">=6"
   }

--- a/packages/istanbul-lib-hook/package.json
+++ b/packages/istanbul-lib-hook/package.json
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "engines": {
     "node": ">=6"
   }

--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs",
+  "homepage": "https://istanbul.js.org/",
   "repository": {
     "type": "git",
     "url": "git@github.com:istanbuljs/istanbuljs.git"

--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs",
+  "homepage": "https://istanbul.js.org/",
   "repository": {
     "type": "git",
     "url": "git@github.com:istanbuljs/istanbuljs.git"

--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git"

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -30,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs",
+  "homepage": "https://istanbul.js.org/",
   "engines": {
     "node": ">=6"
   }

--- a/packages/nyc-config-babel/package.json
+++ b/packages/nyc-config-babel/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/nyc-config-typescript/package.json
+++ b/packages/nyc-config-typescript/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
-  "homepage": "https://github.com/istanbuljs/istanbuljs#readme",
+  "homepage": "https://istanbul.js.org/",
   "dependencies": {
     "arrify": "^1.0.1",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
`npm home istanbul-lib-instrument` should open https://istanbul.js.org/.
`npm home` from the lerna root should open
https://github.com/istanbuljs/istanbuljs.