### PR TITLE
feat: set medium colour to yellow

### DIFF
--- a/packages/istanbul-reports/lib/html/assets/base.css
+++ b/packages/istanbul-reports/lib/html/assets/base.css
@@ -172,16 +172,17 @@ table.coverage td span.cline-any {
 /* dark green */
 .status-line.high, .high .cover-fill { background:rgb(77,146,33) }
 .high .chart { border:1px solid rgb(77,146,33) }
-
-.medium .chart { border:1px solid #666; }
-.medium .cover-fill { background: #666; }
+/* dark yellow (gold) */
+.status-line.medium, .medium .cover-fill { background: #f9cd0b; }
+.medium .chart { border:1px solid #f9cd0b; }
+/* light yellow */
+.medium { background: #fff4c2; }
 
 .cstat-skip { background: #ddd; color: #111; }
 .fstat-skip { background: #ddd; color: #111 !important; }
 .cbranch-skip { background: #ddd !important; color: #111; }
 
 span.cline-neutral { background: #eaeaea; }
-.medium { background: #eaeaea; }
 
 .coverage-summary td.empty {
     opacity: .5;


### PR DESCRIPTION
As discussed in https://github.com/gotwarlost/istanbul/issues/542, this
PR brings back the yellow colour for medium.

There are many good points raised in that PR, and this PR, aims to
replicate address those concerns for this repo.