### PR TITLE
chore: ES2015ify test-exclude.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ node_js:
   - 10
   - 8
   - 6
+matrix:
+## An ENOMEM error occurs with 11.x.x under Travis-CI for Windows.
+## Disable until https://github.com/nodejs/node/issues/25484 is resolved.
+#  include:
+#    - os: windows
+#      node_js: "latest"
+  exclude:
+    - os: windows
+      node_js: "node"
 
 env:
   global:

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -1,122 +1,114 @@
+const path = require('path');
 const arrify = require('arrify');
 const minimatch = require('minimatch');
-const path = require('path');
 const readPkgUp = require('read-pkg-up');
 const requireMainFilename = require('require-main-filename');
 
-function TestExclude(opts) {
-    Object.assign(
-        this,
-        {
-            cwd: process.cwd(),
-            include: false,
-            relativePath: true,
-            configKey: null, // the key to load config from in package.json.
-            configPath: null, // optionally override requireMainFilename.
-            configFound: false
-        },
-        opts
-    );
+class TestExclude {
+    constructor(opts) {
+        Object.assign(
+            this,
+            {
+                cwd: process.cwd(),
+                include: false,
+                relativePath: true,
+                configKey: null, // the key to load config from in package.json.
+                configPath: null, // optionally override requireMainFilename.
+                configFound: false
+            },
+            opts
+        );
 
-    if (typeof this.include === 'string') this.include = [this.include];
-    if (typeof this.exclude === 'string') this.exclude = [this.exclude];
+        if (typeof this.include === 'string') {
+            this.include = [this.include];
+        }
 
-    if (!this.include && !this.exclude && this.configKey) {
-        Object.assign(this, this.pkgConf(this.configKey, this.configPath));
+        if (typeof this.exclude === 'string') {
+            this.exclude = [this.exclude];
+        }
+
+        if (!this.include && !this.exclude && this.configKey) {
+            Object.assign(this, this.pkgConf(this.configKey, this.configPath));
+        }
+
+        if (!this.exclude || !Array.isArray(this.exclude)) {
+            this.exclude = exportFunc.defaultExclude;
+        }
+
+        if (this.include && this.include.length > 0) {
+            this.include = prepGlobPatterns(arrify(this.include));
+        } else {
+            this.include = false;
+        }
+
+        if (!this.exclude.includes('**/node_modules/**')) {
+            this.exclude.push('**/node_modules/**');
+        }
+
+        this.exclude = prepGlobPatterns([].concat(arrify(this.exclude)));
+
+        this.handleNegation();
     }
 
-    if (!this.exclude || !Array.isArray(this.exclude)) {
-        this.exclude = exportFunc.defaultExclude;
+    /* handle the special case of negative globs
+     * (!**foo/bar); we create a new this.excludeNegated set
+     * of rules, which is applied after excludes and we
+     * move excluded include rules into this.excludes.
+     */
+    handleNegation() {
+        const noNeg = e => e.charAt(0) !== '!';
+        const onlyNeg = e => e.charAt(0) === '!';
+        const stripNeg = e => e.slice(1);
+
+        if (Array.isArray(this.include)) {
+            const includeNegated = this.include.filter(onlyNeg).map(stripNeg);
+            this.exclude.push(...prepGlobPatterns(includeNegated));
+            this.include = this.include.filter(noNeg);
+        }
+
+        this.excludeNegated = this.exclude.filter(onlyNeg).map(stripNeg);
+        this.exclude = this.exclude.filter(noNeg);
+        this.excludeNegated = prepGlobPatterns(this.excludeNegated);
     }
 
-    if (this.include && this.include.length > 0) {
-        this.include = prepGlobPatterns(arrify(this.include));
-    } else {
-        this.include = false;
+    shouldInstrument(filename, relFile) {
+        let pathToCheck = filename;
+
+        if (this.relativePath) {
+            relFile = relFile || path.relative(this.cwd, filename);
+
+            // Don't instrument files that are outside of the current working directory.
+            if (/^\.\./.test(path.relative(this.cwd, filename))) {
+                return false;
+            }
+
+            pathToCheck = relFile.replace(/^\.[\\/]/, ''); // remove leading './' or '.\'.
+        }
+
+        const dot = { dot: true };
+        const matches = pattern => minimatch(pathToCheck, pattern, dot);
+        return (
+            (!this.include || this.include.some(matches)) &&
+            (!this.exclude.some(matches) || this.excludeNegated.some(matches))
+        );
     }
 
-    if (this.exclude.indexOf('**/node_modules/**') === -1) {
-        this.exclude.push('**/node_modules/**');
-    }
+    pkgConf(key, path) {
+        const cwd = path || requireMainFilename(require);
+        const obj = readPkgUp.sync({ cwd });
 
-    this.exclude = prepGlobPatterns([].concat(arrify(this.exclude)));
+        if (obj.pkg && obj.pkg[key] && typeof obj.pkg[key] === 'object') {
+            this.configFound = true;
 
-    this.handleNegation();
-}
+            return obj.pkg[key];
+        }
 
-// handle the special case of negative globs
-// (!**foo/bar); we create a new this.excludeNegated set
-// of rules, which is applied after excludes and we
-// move excluded include rules into this.excludes.
-TestExclude.prototype.handleNegation = function() {
-    if (Array.isArray(this.include)) {
-        const includeNegated = this.include
-            .filter(function(e) {
-                return e.charAt(0) === '!';
-            })
-            .map(function(e) {
-                return e.slice(1);
-            });
-        this.exclude.push.apply(this.exclude, prepGlobPatterns(includeNegated));
-        this.include = this.include.filter(function(e) {
-            return e.charAt(0) !== '!';
-        });
-    }
-
-    this.excludeNegated = this.exclude
-        .filter(function(e) {
-            return e.charAt(0) === '!';
-        })
-        .map(function(e) {
-            return e.slice(1);
-        });
-    this.exclude = this.exclude.filter(function(e) {
-        return e.charAt(0) !== '!';
-    });
-    this.excludeNegated = prepGlobPatterns(this.excludeNegated);
-};
-
-TestExclude.prototype.shouldInstrument = function(filename, relFile) {
-    var pathToCheck = filename;
-
-    if (this.relativePath) {
-        relFile = relFile || path.relative(this.cwd, filename);
-
-        // Don't instrument files that are outside of the current working directory.
-        if (/^\.\./.test(path.relative(this.cwd, filename))) return false;
-
-        pathToCheck = relFile.replace(/^\.[\\/]/, ''); // remove leading './' or '.\'.
-    }
-
-    return (
-        (!this.include ||
-            this.include.some(include =>
-                minimatch(pathToCheck, include, { dot: true })
-            )) &&
-        (!this.exclude.some(exclude =>
-            minimatch(pathToCheck, exclude, { dot: true })
-        ) ||
-            this.excludeNegated.some(exclude =>
-                minimatch(pathToCheck, exclude, { dot: true })
-            ))
-    );
-};
-
-TestExclude.prototype.pkgConf = function(key, path) {
-    const obj = readPkgUp.sync({
-        cwd: path || requireMainFilename(require)
-    });
-
-    if (obj.pkg && obj.pkg[key] && typeof obj.pkg[key] === 'object') {
-        this.configFound = true;
-        return obj.pkg[key];
-    } else {
         return {};
     }
-};
+}
 
 function prepGlobPatterns(patterns) {
-    return patterns.reduce(function(result, pattern) {
+    return patterns.reduce((result, pattern) => {
         // Allow gitignore style of directory exclusion
         if (!/\/\*\*$/.test(pattern)) {
             result = result.concat(pattern.replace(/\/$/, '') + '/**');
@@ -131,9 +123,7 @@ function prepGlobPatterns(patterns) {
     }, []);
 }
 
-var exportFunc = function(opts) {
-    return new TestExclude(opts);
-};
+const exportFunc = opts => new TestExclude(opts);
 
 exportFunc.defaultExclude = [
     'coverage/**',

--- a/packages/test-exclude/test/fixtures/subprocess/bin/subprocess.js
+++ b/packages/test-exclude/test/fixtures/subprocess/bin/subprocess.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const testExclude = require('../../../..');
+
+const e = testExclude({
+    configKey: 'a'
+});
+
+assert.strictEqual(e.configFound, true);
+assert.strictEqual(e.shouldInstrument('foo.js'), true);
+assert.strictEqual(e.shouldInstrument('batman.js'), false);

--- a/packages/test-exclude/test/fixtures/subprocess/package.json
+++ b/packages/test-exclude/test/fixtures/subprocess/package.json
@@ -1,0 +1,5 @@
+{
+  "a": {
+    "exclude": ["**batman.js**"]
+  }
+}


### PR DESCRIPTION
* Use node.js 6 features
* Expand test coverage to 100%

---

Next step will be to add support for `getAllFiles` so we can centralize some more of the include/exclude logic here.