### PR TITLE
Fix branchMap in file merging

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file.js
+++ b/packages/istanbul-lib-coverage/lib/file.js
@@ -266,13 +266,24 @@ FileCoverage.prototype.merge = function(other) {
         that.data.f[k] += other.f[k];
     });
     Object.keys(other.b).forEach(function(k) {
-        var i,
-            retArray = that.data.b[k],
-            secondArray = other.b[k];
+
+        var retArray = that.data.b[k];
+        var secondArray = other.b[k];
         if (!retArray) {
             that.data.b[k] = secondArray;
-            return;
         }
+
+        var branchMapThis = that.data.branchMap[k];
+        var branchMapOther = other.branchMap[k];
+        if (!branchMapThis) {
+          that.data.branchMap[k] = branchMapOther;
+        }
+
+        if(!retArray || !branchMapThis) {
+          return;
+        }
+
+        var i;
         for (i = 0; i < retArray.length; i += 1) {
             retArray[i] += secondArray[i];
         }


### PR DESCRIPTION
Nyc version: `13.3.0`
Used: mocha, typescript (ts-node), nodejs
Environment: Gitbash / Windows 10

Sometimes (randomly) I'm getting a bug where `nyc` can't generate `lcovonly` report (with `nyc report`). The problem is in these generated .json files, i.e. I need to restart my tests to get a correct coverage files. Then `nyc report` will work fine.

Error log:

```
$ nyc report
D:\Program Files\npm\npm\node_modules\nyc\node_modules\yargs\yargs.js:1148
      else throw err
           ^

TypeError: Cannot read property 'loc' of undefined
    at D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-reports\lib\lcovonly\index.js:52:25
    at Array.forEach (<anonymous>)
    at LcovOnlyReport.onDetail (D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-reports\lib\lcovonly\index.js:49:27)
    at Visitor.(anonymous function) [as onDetail] (D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:34:30)
    at ReportNode.Node.visit (D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:121:17)
    at D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:114:23
    at Array.forEach (<anonymous>)
    at visitChildren (D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:113:32)
    at ReportNode.Node.visit (D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:124:5)
    at D:\Program Files\npm\npm\node_modules\nyc\node_modules\istanbul-lib-report\lib\tree.js:114:23
```

Nyc crashes when it tries to generate report for my `index.ts` file.

As far as I can tell, there are 3 files generated in .nyc_output folder. 

```
lunar@DESKTOP-S0DCV8G MINGW64 /a/code/work/project/.nyc_output
$ ls -l
total 1024
-rw-r--r-- 1 lunar 197121 105752 Mar  5 20:01 01be25e0-e4c2-411a-8c1c-13385535e8e4.json
-rw-r--r-- 1 lunar 197121 418439 Mar  5 20:01 7ca9e9d6-0d76-4071-8be5-110096771d5f.json
-rw-r--r-- 1 lunar 197121 418439 Mar  5 20:01 c29efb08-6108-4fa4-9fac-2ae7bfa4590b.json
```
They have different data. Two of the files contain a correct data for that `index.ts`, and the third contains nothing:

```

  "A:\\code\\work\\project\\packages\\my_package\\src\\index.ts": {
    "path": "A:\\code\\work\\project\\packages\\my_package\\src\\index.ts",
    "statementMap": {},
    "fnMap": {},
    "branchMap": {},
    "s": {},
    "f": {},
    "b": {}
  },
```

As far as I can tell, .json files are merged together when `nyc report` is called. 

There is a bug in the merging function, which merges `.b` properties but doesn't merge `.branchMap`.
The merge process starts with my "empty" report file, then merges `.b` properties in it (but skips `.branchMap` properties). Then, `lcovonly` generator thinks that both `.b` and `.branchMap` objects have the same keys, but, in fact, `.branchMap` appears to be empty.


Hence the pull request with the bug fix. 
