### PR TITLE
chore: Block node 11.11.0 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
   - linux
 node_js:
-  - 'node'
+  - '11.10.1'
   - 10
   - 8
   - 6
@@ -16,7 +16,7 @@ matrix:
 #      node_js: "latest"
   exclude:
     - os: windows
-      node_js: "node"
+      node_js: "11.10.1"
 
 env:
   global:


### PR DESCRIPTION
This is needed until we can figure out what is going on with node.js 11.11.0.