### PR TITLE
chore: Upgrade js-yaml to 3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4955,14 +4955,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4977,20 +4975,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5107,8 +5102,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5120,7 +5114,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5135,7 +5128,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5143,14 +5135,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5169,7 +5159,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5250,8 +5239,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5263,7 +5251,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5385,7 +5372,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6801,9 +6787,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-prettier": "^3.0.0",
     "is-windows": "^1.0.2",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.0",
     "lerna": "^3.11.1",
     "memory-streams": "^0.1.3",
     "mocha": "^6.0.0",

--- a/packages/istanbul-api/package-lock.json
+++ b/packages/istanbul-api/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-api",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -91,9 +91,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"js-yaml": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"

--- a/packages/istanbul-api/package.json
+++ b/packages/istanbul-api/package.json
@@ -35,7 +35,7 @@
     "istanbul-lib-report": "^2.0.5",
     "istanbul-lib-source-maps": "^3.0.3",
     "istanbul-reports": "^2.2.0",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.0",
     "make-dir": "^2.1.0",
     "minimatch": "^3.0.4",
     "once": "^1.4.0"

--- a/packages/istanbul-lib-hook/package-lock.json
+++ b/packages/istanbul-lib-hook/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-lib-hook",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/istanbul-lib-instrument/package-lock.json
+++ b/packages/istanbul-lib-instrument/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-lib-instrument",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/istanbul-lib-report/package-lock.json
+++ b/packages/istanbul-lib-report/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-lib-report",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/istanbul-lib-source-maps/package-lock.json
+++ b/packages/istanbul-lib-source-maps/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-lib-source-maps",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/istanbul-reports/package-lock.json
+++ b/packages/istanbul-reports/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "istanbul-reports",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/test-exclude/package-lock.json
+++ b/packages/test-exclude/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "test-exclude",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Npm audit reports security vulnerability on js-yaml < 3.13.0