### PR TITLE
fix copy of arrow png on html report

### DIFF
--- a/packages/istanbul-lib-report/lib/file-writer.js
+++ b/packages/istanbul-lib-report/lib/file-writer.js
@@ -165,7 +165,13 @@ FileWriter.prototype.copyFile = function(source, dest, header) {
     }
     dest = path.resolve(this.baseDir, dest);
     mkdirp.sync(path.dirname(dest));
-    fs.writeFileSync(dest, (header || '') + fs.readFileSync(source));
+    let contents;
+    if (header) {
+        contents = header + fs.readFileSync(source, 'utf8');
+    } else {
+        contents = fs.readFileSync(source);
+    }
+    fs.writeFileSync(dest, contents);
 };
 /**
  * returns a content writer for writing content to the supplied file.

--- a/packages/istanbul-lib-report/test/file-writer.test.js
+++ b/packages/istanbul-lib-report/test/file-writer.test.js
@@ -47,6 +47,19 @@ describe('file-writer', () => {
         );
     });
 
+    it('copies binary files', () => {
+        const testBuffer = Buffer.from([195, 40]);
+        fs.writeFileSync(path.resolve(dataDir, 'in.bin'), testBuffer);
+        writer.copyFile(path.resolve(dataDir, 'in.bin'), 'out.bin');
+        assert.equal(
+            Buffer.compare(
+                fs.readFileSync(path.resolve(dataDir, 'out.bin')),
+                testBuffer
+            ),
+            0
+        );
+    });
+
     it('copies files while adding headers', () => {
         const header =
             '/* This is some header text, like a copyright or directive. */\n';


### PR DESCRIPTION
This meant that the sort indicator arrows were broken (on windows 10 chrome anyway)