### PR TITLE
chore: Add greenkeeper.json configuration.

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,15 @@
+{
+  "groups": {
+    "default": {
+      "packages": [
+        "package.json",
+        "packages/*/package.json"
+      ],
+      "ignore": [
+        "source-map",
+        "make-dir",
+        "read-pkg-up"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This (hopefully) configures greenkeeper to report updates for the actual
packages.  This will also enable testing of in-range upates.

The ignore list is modules that require node.js 8, we won't be dropping
node.js 6 until nyc@15.