### PR TITLE
fix: Remove `**/node_modules/**` from defaultExclude.

### DIFF
--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -57,7 +57,7 @@ class TestExclude {
             this.excludeNodeModules &&
             !this.exclude.includes('**/node_modules/**')
         ) {
-            this.exclude.push('**/node_modules/**');
+            this.exclude = this.exclude.concat('**/node_modules/**');
         }
 
         this.exclude = prepGlobPatterns([].concat(arrify(this.exclude)));
@@ -181,7 +181,6 @@ exportFunc.defaultExclude = [
     'test{,-*}.js',
     '**/*{.,-}test.js',
     '**/__tests__/**',
-    '**/node_modules/**',
     `**/{${devConfigs.join()}}.config.js`
 ];
 

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -214,7 +214,6 @@ describe('testExclude', () => {
             'test{,-*}.js',
             '**/*{.,-}test.js',
             '**/__tests__/**',
-            '**/node_modules/**',
             '**/{ava,babel,jest,nyc,rollup,webpack}.config.js'
         ]);
     });


### PR DESCRIPTION
This is appended to the `exclude` list unless excludeNodeModules is
disabled.  Removing from the default list makes it easier to use
excludeNodeModules as you no longer need to reset the `exclude` array to
get coverage of node_modules.

Fixes #347