### PR TITLE
fix: Be more friendly to ts-node.

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -534,7 +534,6 @@ const coverageTemplate = template(`
         if (coverage[path] && coverage[path].hash === hash) {
             return coverage[path];
         }
-        coverageData.hash = hash;
         return coverage[path] = coverageData;
     })();
 `);
@@ -619,8 +618,10 @@ function programVisitor(
             const hash = createHash(SHA)
                 .update(JSON.stringify(coverageData))
                 .digest('hex');
+            coverageData.hash = hash;
             const coverageNode = T.valueToNode(coverageData);
             delete coverageData[MAGIC_KEY];
+            delete coverageData.hash;
             let gvTemplate;
             if (opts.coverageGlobalScopeFunc) {
                 gvTemplate = globalTemplateFunction({

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -515,8 +515,11 @@ const codeVisitor = {
     ConditionalExpression: entries(coverTernary),
     LogicalExpression: entries(coverLogicalExpression)
 };
-const globalTemplateFunction = template(`
+const globalTemplateAlteredFunction = template(`
         var Function = (function(){}).constructor;
+        var global = (new Function(GLOBAL_COVERAGE_SCOPE))();
+`);
+const globalTemplateFunction = template(`
         var global = (new Function(GLOBAL_COVERAGE_SCOPE))();
 `);
 const globalTemplateVariable = template(`
@@ -624,11 +627,19 @@ function programVisitor(
             delete coverageData.hash;
             let gvTemplate;
             if (opts.coverageGlobalScopeFunc) {
-                gvTemplate = globalTemplateFunction({
-                    GLOBAL_COVERAGE_SCOPE: T.stringLiteral(
-                        'return ' + opts.coverageGlobalScope
-                    )
-                });
+                if (path.scope.getBinding('Function')) {
+                    gvTemplate = globalTemplateAlteredFunction({
+                        GLOBAL_COVERAGE_SCOPE: T.stringLiteral(
+                            'return ' + opts.coverageGlobalScope
+                        )
+                    });
+                } else {
+                    gvTemplate = globalTemplateFunction({
+                        GLOBAL_COVERAGE_SCOPE: T.stringLiteral(
+                            'return ' + opts.coverageGlobalScope
+                        )
+                    });
+                }
             } else {
                 gvTemplate = globalTemplateVariable({
                     GLOBAL_COVERAGE_SCOPE: opts.coverageGlobalScope

--- a/packages/istanbul-lib-instrument/test/util/verifier.js
+++ b/packages/istanbul-lib-instrument/test/util/verifier.js
@@ -73,7 +73,13 @@ class Verifier {
         );
         const initial = readInitialCoverage(this.getGeneratedCode());
         assert.ok(initial);
-        assert.deepEqual(initial.coverageData, this.result.emptyCoverage);
+        assert.deepEqual(
+            initial.coverageData,
+            Object.assign(
+                { hash: initial.coverageData.hash },
+                this.result.emptyCoverage
+            )
+        );
         assert.ok(initial.path);
         if (this.result.file) {
             assert.equal(initial.path, this.result.file);

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -202,6 +202,30 @@ describe('varia', () => {
         assert.ok(code.match(/cov_(.+);export class App extends/));
     });
 
+    it('declares Function when needed', () => {
+        const v = verifier.create(
+            'function Function() {}',
+            { generateOnly: true },
+            { esModules: true }
+        );
+        assert.ok(!v.err);
+
+        const code = v.getGeneratedCode();
+        assert.ok(code.match(/var Function\s*=/));
+    });
+
+    it('does not declare Function when not needed', () => {
+        const v = verifier.create(
+            'function differentFunction() {}',
+            { generateOnly: true },
+            { esModules: true }
+        );
+        assert.ok(!v.err);
+
+        const code = v.getGeneratedCode();
+        assert.ok(!code.match(/var Function\s*=/));
+    });
+
     it('does not add extra parenthesis when superclass is an identifier', () => {
         const v = verifier.create('class App extends Component {};', {
             generateOnly: true


### PR DESCRIPTION
ts-node gets angry when coverageData.hash is set after coverageData is
declared, add it to the initial object instead of setting it separately.

Fixes #336

---

Note for the instrumentation to be error-free with ts-node requires getting rid of the `var Function = (function(){}).constructor;`.  I know this was added for a reason, I don't want to create an explosion of new options.  So for now the `istanbul-lib-instrument` answer is to set the following options:
```js
{
  coverageGlobalScopeFunc: false,
  coverageGlobalScope: '(new Function("return this"))()'
}
```

I believe using these options would produce ts-node compatible code.  Unfortunately these options are not exposed by nyc or babel-plugin-istanbul.