### PR TITLE
feat: Add bigInt and importMeta to default parser plugins.

### DIFF
--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -21,9 +21,18 @@ export function defaultOpts() {
         ignoreClassMethods: [],
         sourceMapUrlCallback: null,
         debug: false,
+        /* babel parser plugins are to be enabled when the feature is stage 3 and
+         * implemented in a released version of node.js */
         plugins: [
             'asyncGenerators',
+            'bigInt',
+            /* Verify and add upon release of node.js 12:
+             * classProperties
+             * classPrivateProperties
+             * classPrivateMethods
+             */
             'dynamicImport',
+            'importMeta',
             'objectRestSpread',
             'optionalCatchBinding',
             'flow',


### PR DESCRIPTION
This allows code with these features to be instrumented without having
to reconfigure the parser plugins.

Fixes #338