### PR TITLE
Update handlebars version for security fix

### DIFF
--- a/packages/istanbul-reports/package-lock.json
+++ b/packages/istanbul-reports/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "istanbul-reports",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"optional": true
 		},
 		"handlebars": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -46,12 +46,12 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"uglify-js": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
-			"integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+			"integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
 			"optional": true,
 			"requires": {
-				"commander": "~2.19.0",
+				"commander": "~2.20.0",
 				"source-map": "~0.6.1"
 			}
 		},

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -12,7 +12,7 @@
     "test": "mocha --recursive"
   },
   "dependencies": {
-    "handlebars": "^4.1.0"
+    "handlebars": "^4.1.2"
   },
   "devDependencies": {
     "istanbul-lib-coverage": "^2.0.4",


### PR DESCRIPTION
This PR upgrades dependency `handlebars` to v4.1.2 to fix the security vulnerability described here: https://www.npmjs.com/advisories/755

This is currently being flagged as vulnerable by `npm audit`. This will need a new release to be effective of course.