### PR TITLE
fix sorting

### DIFF
--- a/packages/istanbul-reports/lib/html/assets/sorter.js
+++ b/packages/istanbul-reports/lib/html/assets/sorter.js
@@ -159,7 +159,7 @@ var addSorting = (function() {
         if (!getTable()) {
             return;
         }
-        loadColumns();
+        cols = loadColumns();
         loadData();
         addSortIndicators();
         enableUI();


### PR DESCRIPTION
https://github.com/istanbuljs/istanbuljs/pull/289 broke sorting as it removed the assignment to `cols` which is referenced later on
https://github.com/istanbuljs/istanbuljs/blob/9dac4c6fe63e089f0296f17ba295e64d02b3334d/packages/istanbul-reports/lib/html/assets/sorter.js#L61

In a web browser loading the html report gives the following in the web console:
```console
TypeError: cols is undefined[Learn More] sorter.js:62:13
    loadRowData https://coverage.nodejs.org/coverage-09cdc3782488d2e6/sorter.js:62
    loadData https://coverage.nodejs.org/coverage-09cdc3782488d2e6/sorter.js:77
    addSorting https://coverage.nodejs.org/coverage-09cdc3782488d2e6/sorter.js:164
```

cc @Trott