### PR TITLE
fix: if LEAST_UPPER_BOUND returns null, try GREATEST_LOWER_BOUND

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/get-mapping.js
+++ b/packages/istanbul-lib-source-maps/lib/get-mapping.js
@@ -74,22 +74,20 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
 
 /**
 * Attempts to determine the original source position, first
-* trying LEAST_UPPER_BOUND which returns the closest
-* element larger than the element we were searching for. If this fails, we next
-* try GREATEST_LOWER_BOUND, which returns the closest element smaller than
-* the element being searched for.
+* returning the closest element to the left (GREATEST_LOWER_BOUND),
+* and next returning the closest element to the right (LEAST_UPPER_BOUND).
 */
 function originalPositionTryBoth (sourceMap, line, column) {
   let mapping = sourceMap.originalPositionFor({
       line: line,
       column: column,
-      bias: LEAST_UPPER_BOUND
+      bias: GREATEST_LOWER_BOUND
   });
   if (mapping.source === null) {
     mapping = sourceMap.originalPositionFor({
         line: line,
         column: column,
-        bias: GREATEST_LOWER_BOUND
+        bias: LEAST_UPPER_BOUND
     });
   }
   return mapping;

--- a/packages/istanbul-lib-source-maps/lib/get-mapping.js
+++ b/packages/istanbul-lib-source-maps/lib/get-mapping.js
@@ -81,19 +81,20 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
  * and next returning the closest element to the right (LEAST_UPPER_BOUND).
  */
 function originalPositionTryBoth(sourceMap, line, column) {
-    let mapping = sourceMap.originalPositionFor({
+    const mapping = sourceMap.originalPositionFor({
         line,
         column,
         bias: GREATEST_LOWER_BOUND
     });
     if (mapping.source === null) {
-        mapping = sourceMap.originalPositionFor({
+        return sourceMap.originalPositionFor({
             line,
             column,
             bias: LEAST_UPPER_BOUND
         });
+    } else {
+        return mapping;
     }
-    return mapping;
 }
 
 function isInvalidPosition(pos) {

--- a/packages/istanbul-lib-source-maps/lib/get-mapping.js
+++ b/packages/istanbul-lib-source-maps/lib/get-mapping.js
@@ -5,7 +5,10 @@
 'use strict';
 
 const pathutils = require('./pathutils');
-const {GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND} = require('source-map').SourceMapConsumer;
+const {
+    GREATEST_LOWER_BOUND,
+    LEAST_UPPER_BOUND
+} = require('source-map').SourceMapConsumer;
 
 /**
  * AST ranges are inclusive for start positions and exclusive for end positions.
@@ -31,13 +34,13 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
     // generated file end location. Note however that this position on its
     // own is not useful because it is the position of the _start_ of the range
     // on the original file, and we want the _end_ of the range.
-    let beforeEndMapping = originalPositionTryBoth(
-      sourceMap,
-      generatedEnd.line,
-      generatedEnd.column - 1
+    const beforeEndMapping = originalPositionTryBoth(
+        sourceMap,
+        generatedEnd.line,
+        generatedEnd.column - 1
     );
     if (beforeEndMapping.source === null) {
-      return null;
+        return null;
     }
 
     // Convert that original position back to a generated one, with a bump
@@ -73,24 +76,24 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
 }
 
 /**
-* Attempts to determine the original source position, first
-* returning the closest element to the left (GREATEST_LOWER_BOUND),
-* and next returning the closest element to the right (LEAST_UPPER_BOUND).
-*/
-function originalPositionTryBoth (sourceMap, line, column) {
-  let mapping = sourceMap.originalPositionFor({
-      line: line,
-      column: column,
-      bias: GREATEST_LOWER_BOUND
-  });
-  if (mapping.source === null) {
-    mapping = sourceMap.originalPositionFor({
-        line: line,
-        column: column,
-        bias: LEAST_UPPER_BOUND
+ * Attempts to determine the original source position, first
+ * returning the closest element to the left (GREATEST_LOWER_BOUND),
+ * and next returning the closest element to the right (LEAST_UPPER_BOUND).
+ */
+function originalPositionTryBoth(sourceMap, line, column) {
+    let mapping = sourceMap.originalPositionFor({
+        line,
+        column,
+        bias: GREATEST_LOWER_BOUND
     });
-  }
-  return mapping;
+    if (mapping.source === null) {
+        mapping = sourceMap.originalPositionFor({
+            line,
+            column,
+            bias: LEAST_UPPER_BOUND
+        });
+    }
+    return mapping;
 }
 
 function isInvalidPosition(pos) {
@@ -122,9 +125,9 @@ function getMapping(sourceMap, generatedLocation, origFile) {
     }
 
     const start = originalPositionTryBoth(
-      sourceMap,
-      generatedLocation.start.line,
-      generatedLocation.start.column
+        sourceMap,
+        generatedLocation.start.line,
+        generatedLocation.start.column
     );
     let end = originalEndPositionFor(sourceMap, generatedLocation.end);
 


### PR DESCRIPTION
I'm running into issues adding source-map support to c8, in which `LEAST_UPPER_BOUND` returns `mapping.source === null`.

If I loosen up our check so that it falls back to the default behavior of `GREATEST_LOWER_BOUND` in this edge-case, c8's remapping works like a charm, see:

<img width="681" alt="Screen Shot 2019-04-20 at 11 46 44 PM" src="https://user-images.githubusercontent.com/194609/56466405-98381f00-63c6-11e9-91e6-ce993a4e4056.png">

----

@loganfsmyth can you clarify for me why this change might address my issues? I understand that they underlying cause is most likely that V8's coverage ranges don't directly map to the mappings generated by TypeScript ... but why would `LEAST_UPPER_BOUND` be returning `null`? 

Reading the documentation, shouldn't it simply return the next closest element that's a greater line number than the element I'm remapping -- I guess I don't fully understand the scenarios that result in `LEAST_UPPER_BOUND` or `GREATEST_LOWER_BOUND` returning `null`.