### PR TITLE
Make the html report into a class and allow the breadcrumb to be overridden

### DIFF
--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -100,100 +100,6 @@ const standardLinkMapper = {
     }
 };
 
-function getBreadcrumbHtml(node, linkMapper) {
-    let parent = node.getParent();
-    const nodePath = [];
-
-    while (parent) {
-        nodePath.push(parent);
-        parent = parent.getParent();
-    }
-
-    const linkPath = nodePath.map(ancestor => {
-        const target = linkMapper.relativePath(node, ancestor);
-        const name = ancestor.getRelativeName() || 'All files';
-        return '<a href="' + target + '">' + name + '</a>';
-    });
-
-    linkPath.reverse();
-    return linkPath.length > 0
-        ? linkPath.join(' / ') + ' ' + node.getRelativeName()
-        : 'All files';
-}
-
-function fillTemplate(node, templateData, linkMapper, context) {
-    const summary = node.getCoverageSummary();
-    templateData.entity = node.getQualifiedName() || 'All files';
-    templateData.metrics = summary;
-    templateData.reportClass = context.classForPercent(
-        'statements',
-        summary.statements.pct
-    );
-    templateData.pathHtml = getBreadcrumbHtml(node, linkMapper);
-    templateData.base = {
-        css: linkMapper.assetPath(node, 'base.css')
-    };
-    templateData.sorter = {
-        js: linkMapper.assetPath(node, 'sorter.js'),
-        image: linkMapper.assetPath(node, 'sort-arrow-sprite.png')
-    };
-    templateData.blockNavigation = {
-        js: linkMapper.assetPath(node, 'block-navigation.js')
-    };
-    templateData.prettify = {
-        js: linkMapper.assetPath(node, 'prettify.js'),
-        css: linkMapper.assetPath(node, 'prettify.css')
-    };
-}
-
-function HtmlReport(opts) {
-    this.verbose = opts.verbose;
-    this.linkMapper = opts.linkMapper || standardLinkMapper;
-    this.subdir = opts.subdir || '';
-    this.date = Date();
-    this.skipEmpty = opts.skipEmpty;
-}
-
-HtmlReport.prototype.getTemplateData = function() {
-    return { datetime: this.date };
-};
-
-HtmlReport.prototype.getWriter = function(context) {
-    if (!this.subdir) {
-        return context.writer;
-    }
-    return context.writer.writerForDir(this.subdir);
-};
-
-HtmlReport.prototype.onStart = function(root, context) {
-    const assetHeaders = {
-        '.js': '/* eslint-disable */\n'
-    };
-
-    ['.', 'vendor'].forEach(subdir => {
-        const writer = this.getWriter(context);
-        const srcDir = path.resolve(__dirname, 'assets', subdir);
-        fs.readdirSync(srcDir).forEach(f => {
-            const resolvedSource = path.resolve(srcDir, f);
-            const resolvedDestination = '.';
-            const stat = fs.statSync(resolvedSource);
-            let dest;
-
-            if (stat.isFile()) {
-                dest = resolvedDestination + '/' + f;
-                if (this.verbose) {
-                    console.log('Write asset: ' + dest);
-                }
-                writer.copyFile(
-                    resolvedSource,
-                    dest,
-                    assetHeaders[path.extname(f)]
-                );
-            }
-        });
-    });
-};
-
 function fixPct(metrics) {
     Object.keys(emptyClasses).forEach(key => {
         metrics[key].pct = 0;
@@ -201,68 +107,168 @@ function fixPct(metrics) {
     return metrics;
 }
 
-HtmlReport.prototype.onSummary = function(node, context) {
-    const linkMapper = this.linkMapper;
-    const templateData = this.getTemplateData();
-    const children = node.getChildren();
-    const skipEmpty = this.skipEmpty;
+class HtmlReport {
+    constructor(opts) {
+        this.verbose = opts.verbose;
+        this.linkMapper = opts.linkMapper || standardLinkMapper;
+        this.subdir = opts.subdir || '';
+        this.date = Date();
+        this.skipEmpty = opts.skipEmpty;
+    }
 
-    fillTemplate(node, templateData, linkMapper, context);
-    const cw = this.getWriter(context).writeFile(linkMapper.getPath(node));
-    cw.write(headerTemplate(templateData));
-    cw.write(summaryTableHeader);
-    children.forEach(child => {
-        const metrics = child.getCoverageSummary();
-        const isEmpty = metrics.isEmpty();
-        if (skipEmpty && isEmpty) {
-            return;
+    getBreadcrumbHtml(node) {
+        let parent = node.getParent();
+        const nodePath = [];
+
+        while (parent) {
+            nodePath.push(parent);
+            parent = parent.getParent();
         }
-        const reportClasses = isEmpty
-            ? emptyClasses
-            : {
-                  statements: context.classForPercent(
-                      'statements',
-                      metrics.statements.pct
-                  ),
-                  lines: context.classForPercent('lines', metrics.lines.pct),
-                  functions: context.classForPercent(
-                      'functions',
-                      metrics.functions.pct
-                  ),
-                  branches: context.classForPercent(
-                      'branches',
-                      metrics.branches.pct
-                  )
-              };
-        const data = {
-            metrics: isEmpty ? fixPct(metrics) : metrics,
-            reportClasses,
-            file: child.getRelativeName(),
-            output: linkMapper.relativePath(node, child)
+
+        const linkPath = nodePath.map(ancestor => {
+            const target = this.linkMapper.relativePath(node, ancestor);
+            const name = ancestor.getRelativeName() || 'All files';
+            return '<a href="' + target + '">' + name + '</a>';
+        });
+
+        linkPath.reverse();
+        return linkPath.length > 0
+            ? linkPath.join(' / ') + ' ' + node.getRelativeName()
+            : 'All files';
+    }
+
+    fillTemplate(node, templateData, context) {
+        const linkMapper = this.linkMapper;
+        const summary = node.getCoverageSummary();
+        templateData.entity = node.getQualifiedName() || 'All files';
+        templateData.metrics = summary;
+        templateData.reportClass = context.classForPercent(
+            'statements',
+            summary.statements.pct
+        );
+        templateData.pathHtml = this.getBreadcrumbHtml(node);
+        templateData.base = {
+            css: linkMapper.assetPath(node, 'base.css')
         };
-        cw.write(summaryLineTemplate(data) + '\n');
-    });
-    cw.write(summaryTableFooter);
-    cw.write(footerTemplate(templateData));
-    cw.close();
-};
+        templateData.sorter = {
+            js: linkMapper.assetPath(node, 'sorter.js'),
+            image: linkMapper.assetPath(node, 'sort-arrow-sprite.png')
+        };
+        templateData.blockNavigation = {
+            js: linkMapper.assetPath(node, 'block-navigation.js')
+        };
+        templateData.prettify = {
+            js: linkMapper.assetPath(node, 'prettify.js'),
+            css: linkMapper.assetPath(node, 'prettify.css')
+        };
+    }
 
-HtmlReport.prototype.onDetail = function(node, context) {
-    const linkMapper = this.linkMapper;
-    const templateData = this.getTemplateData();
+    getTemplateData() {
+        return { datetime: this.date };
+    }
 
-    fillTemplate(node, templateData, linkMapper, context);
-    const cw = this.getWriter(context).writeFile(linkMapper.getPath(node));
-    cw.write(headerTemplate(templateData));
-    cw.write('<pre><table class="coverage">\n');
-    cw.write(
-        detailTemplate(
-            annotator.annotateSourceCode(node.getFileCoverage(), context)
-        )
-    );
-    cw.write('</table></pre>\n');
-    cw.write(footerTemplate(templateData));
-    cw.close();
-};
+    getWriter(context) {
+        if (!this.subdir) {
+            return context.writer;
+        }
+        return context.writer.writerForDir(this.subdir);
+    }
+
+    onStart(root, context) {
+        const assetHeaders = {
+            '.js': '/* eslint-disable */\n'
+        };
+
+        ['.', 'vendor'].forEach(subdir => {
+            const writer = this.getWriter(context);
+            const srcDir = path.resolve(__dirname, 'assets', subdir);
+            fs.readdirSync(srcDir).forEach(f => {
+                const resolvedSource = path.resolve(srcDir, f);
+                const resolvedDestination = '.';
+                const stat = fs.statSync(resolvedSource);
+                let dest;
+
+                if (stat.isFile()) {
+                    dest = resolvedDestination + '/' + f;
+                    if (this.verbose) {
+                        console.log('Write asset: ' + dest);
+                    }
+                    writer.copyFile(
+                        resolvedSource,
+                        dest,
+                        assetHeaders[path.extname(f)]
+                    );
+                }
+            });
+        });
+    }
+
+    onSummary(node, context) {
+        const linkMapper = this.linkMapper;
+        const templateData = this.getTemplateData();
+        const children = node.getChildren();
+        const skipEmpty = this.skipEmpty;
+
+        this.fillTemplate(node, templateData, context);
+        const cw = this.getWriter(context).writeFile(linkMapper.getPath(node));
+        cw.write(headerTemplate(templateData));
+        cw.write(summaryTableHeader);
+        children.forEach(child => {
+            const metrics = child.getCoverageSummary();
+            const isEmpty = metrics.isEmpty();
+            if (skipEmpty && isEmpty) {
+                return;
+            }
+            const reportClasses = isEmpty
+                ? emptyClasses
+                : {
+                      statements: context.classForPercent(
+                          'statements',
+                          metrics.statements.pct
+                      ),
+                      lines: context.classForPercent(
+                          'lines',
+                          metrics.lines.pct
+                      ),
+                      functions: context.classForPercent(
+                          'functions',
+                          metrics.functions.pct
+                      ),
+                      branches: context.classForPercent(
+                          'branches',
+                          metrics.branches.pct
+                      )
+                  };
+            const data = {
+                metrics: isEmpty ? fixPct(metrics) : metrics,
+                reportClasses,
+                file: child.getRelativeName(),
+                output: linkMapper.relativePath(node, child)
+            };
+            cw.write(summaryLineTemplate(data) + '\n');
+        });
+        cw.write(summaryTableFooter);
+        cw.write(footerTemplate(templateData));
+        cw.close();
+    }
+
+    onDetail(node, context) {
+        const linkMapper = this.linkMapper;
+        const templateData = this.getTemplateData();
+
+        this.fillTemplate(node, templateData, context);
+        const cw = this.getWriter(context).writeFile(linkMapper.getPath(node));
+        cw.write(headerTemplate(templateData));
+        cw.write('<pre><table class="coverage">\n');
+        cw.write(
+            detailTemplate(
+                annotator.annotateSourceCode(node.getFileCoverage(), context)
+            )
+        );
+        cw.write('</table></pre>\n');
+        cw.write(footerTemplate(templateData));
+        cw.close();
+    }
+}
 
 module.exports = HtmlReport;


### PR DESCRIPTION
This is the only change required to allow https://github.com/istanbuljs/istanbuljs/pull/345 - because that uses the existing report to generate the file nodes, which include a breadcrumb.. so it overrides the report breadcrumb function.

I thought I would modernize it to a class at the same time, since thats whats been suggested of the classes in #345 