### PR TITLE
Fix the nested summarizer to combine directories

### DIFF
--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -94,6 +94,24 @@ function threeDirMap() {
     return coverage.createCoverageMap(map);
 }
 
+function multiDirMap() {
+    const files = [
+        'lib1/sub/file3.js',
+        'lib1/file4.js',
+        'lib2/sub1/file2.js',
+        'lib2/sub2/file1.js'
+    ];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
 function getStructure(tree, localNames) {
     const meth = localNames ? 'getRelativeName' : 'getQualifiedName';
     const visitor = {
@@ -401,6 +419,23 @@ describe('summarizer', () => {
                 'f:lib1/sub/dir/file2.js',
                 'g:lib2',
                 'f:lib2/file4.js'
+            ]);
+        });
+        it('supports directory in directory', () => {
+            const map = multiDirMap();
+            const tree = fn(map);
+            const nodes = getStructure(tree);
+            assert.deepEqual(nodes, [
+                'g:',
+                'g:lib1',
+                'f:lib1/file4.js',
+                'g:lib1/sub',
+                'f:lib1/sub/file3.js',
+                'g:lib2',
+                'g:lib2/sub1',
+                'f:lib2/sub1/file2.js',
+                'g:lib2/sub2',
+                'f:lib2/sub2/file1.js'
             ]);
         });
     });


### PR DESCRIPTION
the nested summarizer nicely combines directories in this scenario

```
file
lib1/sub/file
```

(e.g. you don't see lib1 and lib1/sub differently)

but in this scenario

```
lib1/sub/file
lib1/sub2/file
```

you don't get to see `lib1` and children `sub` and `sub2` but instead get two entries in the root.. unless there is a file inside `lib1` root.

This makes the report look quite weird and inconsistent when you have certain structures e.g.

```
app/file
app/sub1/file
app/sub2/file
mods/sub1/file
mods/sub2/file
```

here you see

```
app
   file
   sub1
       file
   sub2
       file
mods/sub1
   file
mods/sub2
   file
```

This fixes it. The existing implemnation was imo a bit of a hack - mutating the package transform and my first attempts to just "fix it" just made it worse, so I re-implemented it.