### PR TITLE
fix: Also ignore *.cjs, *.mjs and .*ts by default

### DIFF
--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -177,8 +177,8 @@ exportFunc.defaultExclude = [
     'coverage/**',
     'packages/*/test/**',
     'test/**',
-    'test{,-*}.{,c,m}js',
-    '**/*{.,-}test.{,c,m}js',
+    'test{,-*}.{js,cjs,mjs}',
+    '**/*{.,-}test.{js,cjs,mjs}',
     '**/__tests__/**',
     `**/{${devConfigs.join()}}.config.js`
 ];

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -177,8 +177,8 @@ exportFunc.defaultExclude = [
     'coverage/**',
     'packages/*/test/**',
     'test/**',
-    'test{,-*}.{js,cjs,mjs}',
-    '**/*{.,-}test.{js,cjs,mjs}',
+    'test{,-*}.{js,cjs,mjs,ts}',
+    '**/*{.,-}test.{js,cjs,mjs,ts}',
     '**/__tests__/**',
     `**/{${devConfigs.join()}}.config.js`
 ];

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -180,7 +180,7 @@ exportFunc.defaultExclude = [
     'test{,-*}.{,c,m}js',
     '**/*{.,-}test.{,c,m}js',
     '**/__tests__/**',
-    `**/{${devConfigs.join()}}.config.{,c,m}js`
+    `**/{${devConfigs.join()}}.config.js`
 ];
 
 module.exports = exportFunc;

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -177,10 +177,10 @@ exportFunc.defaultExclude = [
     'coverage/**',
     'packages/*/test/**',
     'test/**',
-    'test{,-*}.js',
-    '**/*{.,-}test.js',
+    'test{,-*}.{,c,m}js',
+    '**/*{.,-}test.{,c,m}js',
     '**/__tests__/**',
-    `**/{${devConfigs.join()}}.config.js`
+    `**/{${devConfigs.join()}}.config.{,c,m}js`
 ];
 
 module.exports = exportFunc;

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -226,7 +226,7 @@ describe('testExclude', () => {
             'test{,-*}.{,c,m}js',
             '**/*{.,-}test.{,c,m}js',
             '**/__tests__/**',
-            '**/{ava,babel,jest,nyc,rollup,webpack}.config.{,c,m}js'
+            '**/{ava,babel,jest,nyc,rollup,webpack}.config.js'
         ]);
     });
 

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -21,7 +21,19 @@ describe('testExclude', () => {
             .shouldInstrument('./test.js')
             .should.equal(false);
         exclude()
+            .shouldInstrument('./test.cjs')
+            .should.equal(false);
+        exclude()
+            .shouldInstrument('./test.mjs')
+            .should.equal(false);
+        exclude()
             .shouldInstrument('./foo.test.js')
+            .should.equal(false);
+        exclude()
+            .shouldInstrument('./foo.test.cjs')
+            .should.equal(false);
+        exclude()
+            .shouldInstrument('./foo.test.mjs')
             .should.equal(false);
     });
 
@@ -211,10 +223,10 @@ describe('testExclude', () => {
             'coverage/**',
             'packages/*/test/**',
             'test/**',
-            'test{,-*}.js',
-            '**/*{.,-}test.js',
+            'test{,-*}.{,c,m}js',
+            '**/*{.,-}test.{,c,m}js',
             '**/__tests__/**',
-            '**/{ava,babel,jest,nyc,rollup,webpack}.config.js'
+            '**/{ava,babel,jest,nyc,rollup,webpack}.config.{,c,m}js'
         ]);
     });
 

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -223,8 +223,8 @@ describe('testExclude', () => {
             'coverage/**',
             'packages/*/test/**',
             'test/**',
-            'test{,-*}.{,c,m}js',
-            '**/*{.,-}test.{,c,m}js',
+            'test{,-*}.{js,cjs,mjs}',
+            '**/*{.,-}test.{js,cjs,mjs}',
             '**/__tests__/**',
             '**/{ava,babel,jest,nyc,rollup,webpack}.config.js'
         ]);

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -27,6 +27,9 @@ describe('testExclude', () => {
             .shouldInstrument('./test.mjs')
             .should.equal(false);
         exclude()
+            .shouldInstrument('./test.ts')
+            .should.equal(false);
+        exclude()
             .shouldInstrument('./foo.test.js')
             .should.equal(false);
         exclude()
@@ -34,6 +37,9 @@ describe('testExclude', () => {
             .should.equal(false);
         exclude()
             .shouldInstrument('./foo.test.mjs')
+            .should.equal(false);
+        exclude()
+            .shouldInstrument('./foo.test.ts')
             .should.equal(false);
     });
 
@@ -223,8 +229,8 @@ describe('testExclude', () => {
             'coverage/**',
             'packages/*/test/**',
             'test/**',
-            'test{,-*}.{js,cjs,mjs}',
-            '**/*{.,-}test.{js,cjs,mjs}',
+            'test{,-*}.{js,cjs,mjs,ts}',
+            '**/*{.,-}test.{js,cjs,mjs,ts}',
             '**/__tests__/**',
             '**/{ava,babel,jest,nyc,rollup,webpack}.config.js'
         ]);


### PR DESCRIPTION
When `--experimental-modules` flag is enabled, those extensions are used to specify whether the script is CommonJS or ES module explicitly. https://nodejs.org/api/esm.html
