### PR TITLE
fix(istanbul-reports): Remove isRoot check causing incorrect report formatting (#66).

### DIFF
--- a/packages/istanbul-reports/lib/cobertura/index.js
+++ b/packages/istanbul-reports/lib/cobertura/index.js
@@ -57,9 +57,6 @@ CoberturaReport.prototype.writeRootStats = function(node) {
 };
 
 CoberturaReport.prototype.onSummary = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
     const metrics = node.getCoverageSummary(true);
     if (!metrics) {
         return;
@@ -72,10 +69,7 @@ CoberturaReport.prototype.onSummary = function(node) {
     this.xml.openTag('classes');
 };
 
-CoberturaReport.prototype.onSummaryEnd = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
+CoberturaReport.prototype.onSummaryEnd = function() {
     this.xml.closeTag('classes');
     this.xml.closeTag('package');
 };


### PR DESCRIPTION
This issue has been hanging out for a long while and seems to have effected a lot of other people. I thought I had discovered a fix by just ensuring my source files were not all in one directory but then the  problem popped up again.

I could not discover a good reason why this check exists, more specifically why it exists only for these tags. In fact, all it seems to do is break the report format when its generated, which means its no good for the Jenkins API :(

This bug has blocked my work several times now so I figured I'd try contributing the fix.