### PR TITLE
chore: Internal refactoring of istanbul-lib-report

### DIFF
--- a/packages/istanbul-lib-report/lib/file-writer.js
+++ b/packages/istanbul-lib-report/lib/file-writer.js
@@ -8,20 +8,11 @@ const mkdirp = require('make-dir');
 const supportsColor = require('supports-color');
 
 /**
- * abstract interface for writing content
+ * Base class for writing content
  * @class ContentWriter
  * @constructor
  */
 class ContentWriter {
-    /**
-     * writes a string as-is to the destination
-     * @param {String} str the string to write
-     */
-    /* istanbul ignore next: abstract class */
-    write() {
-        throw new Error('write: must be overridden');
-    }
-
     /**
      * returns the colorized version of a string. Typically,
      * content writers that write to files will return the

--- a/packages/istanbul-lib-report/lib/path.js
+++ b/packages/istanbul-lib-report/lib/path.js
@@ -83,6 +83,10 @@ class Path {
         return this.v.slice();
     }
 
+    name() {
+        return this.v.slice(-1)[0];
+    }
+
     contains(other) {
         let i;
         if (other.length > this.length) {

--- a/packages/istanbul-lib-report/lib/tree.js
+++ b/packages/istanbul-lib-report/lib/tree.js
@@ -69,8 +69,7 @@ class CompositeVisitor extends Visitor {
         });
     });
 
-class Node {
-    /* istanbul ignore next: abstract method */
+class BaseNode {
     isRoot() {
         return !this.getParent();
     }
@@ -99,36 +98,20 @@ class Node {
     }
 }
 
-const nodeAbstracts = [
-    'getQualifiedName',
-    'getRelativeName',
-    'getParent',
-    'getChildren',
-    'isSummary',
-    'getCoverageSummary',
-    'getFileCoverage'
-];
-
-nodeAbstracts.forEach(fn => {
-    /* istanbul ignore next: abstract method */
-    Object.defineProperty(Node.prototype, fn, {
-        value() {
-            throw new Error(`${fn} must be overridden`);
-        }
-    });
-});
-
 /**
  * abstract base class for a coverage tree.
  * @constructor
  */
-class Tree {
+class BaseTree {
+    constructor(root) {
+        this.root = root;
+    }
+
     /**
      * returns the root node of the tree
      */
-    /* istanbul ignore next: abstract method */
     getRoot() {
-        throw new Error('getRoot must be overridden');
+        return this.root;
     }
 
     /**
@@ -147,8 +130,8 @@ class Tree {
 }
 
 module.exports = {
-    Tree,
-    Node,
+    BaseTree,
+    BaseNode,
     Visitor,
     CompositeVisitor
 };

--- a/packages/istanbul-lib-report/test/tree.test.js
+++ b/packages/istanbul-lib-report/test/tree.test.js
@@ -1,12 +1,12 @@
 /* globals describe, it, beforeEach */
 
 const assert = require('chai').assert;
-const t = require('../lib/tree');
-
-const BaseTree = t.Tree;
-const BaseNode = t.Node;
-const Visitor = t.Visitor;
-const CompositeVisitor = t.CompositeVisitor;
+const {
+    BaseTree,
+    BaseNode,
+    Visitor,
+    CompositeVisitor
+} = require('../lib/tree');
 
 class TestNode extends BaseNode {
     constructor(name) {
@@ -63,10 +63,7 @@ describe('tree', () => {
         const root = new TestNode('root');
         root.addChild(groups[0]);
         root.addChild(groups[2]);
-        tree = new BaseTree();
-        tree.getRoot = function() {
-            return root;
-        };
+        tree = new BaseTree(root);
     });
 
     describe('single visitor', () => {


### PR DESCRIPTION
* Drop "abstract" functions
* Rename Node and Tree to BaseNode and BaseTree
* Create ReportNode.createRoot static method
* Replace treeFor with ReportTree class
* Simplify multiple internal `summarizer.js` functions
* Implement getRoot in BaseTree

Ref #390

---

Will be additional follow-up but this is likely the last of the non-breaking changes for istanbul-lib-report.

CC @lukeapage