### PR TITLE
chore: Move default excludes to stand-alone file

### DIFF
--- a/packages/test-exclude/default-exclude.js
+++ b/packages/test-exclude/default-exclude.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const devConfigs = ['ava', 'babel', 'jest', 'nyc', 'rollup', 'webpack'];
+
+module.exports = [
+    'coverage/**',
+    'packages/*/test/**',
+    'test/**',
+    'test{,-*}.{js,cjs,mjs,ts}',
+    '**/*{.,-}test.{js,cjs,mjs,ts}',
+    '**/__tests__/**',
+    `**/{${devConfigs.join()}}.config.js`
+];

--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -1,8 +1,11 @@
+'use strict';
+
 const path = require('path');
 const glob = require('glob');
 const minimatch = require('minimatch');
 const readPkgUp = require('read-pkg-up');
 const requireMainFilename = require('require-main-filename');
+const defaultExclude = require('./default-exclude');
 
 class TestExclude {
     constructor(opts) {
@@ -43,7 +46,7 @@ class TestExclude {
         }
 
         if (!this.exclude || !Array.isArray(this.exclude)) {
-            this.exclude = exportFunc.defaultExclude;
+            this.exclude = defaultExclude;
         }
 
         if (this.include && this.include.length > 0) {
@@ -171,16 +174,6 @@ function getExtensionPattern(extension) {
 
 const exportFunc = opts => new TestExclude(opts);
 
-const devConfigs = ['ava', 'babel', 'jest', 'nyc', 'rollup', 'webpack'];
-
-exportFunc.defaultExclude = [
-    'coverage/**',
-    'packages/*/test/**',
-    'test/**',
-    'test{,-*}.{js,cjs,mjs,ts}',
-    '**/*{.,-}test.{js,cjs,mjs,ts}',
-    '**/__tests__/**',
-    `**/{${devConfigs.join()}}.config.js`
-];
+exportFunc.defaultExclude = defaultExclude;
 
 module.exports = exportFunc;

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -4,7 +4,7 @@
   "description": "test for inclusion or exclusion of paths using pkg-conf and globs",
   "main": "index.js",
   "files": [
-    "index.js"
+    "*.js"
   ],
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
This allows documentation to provide a permanent link to the master
version of the default exclude list.

---

CC @JaKXz once we do this we can update the nyc readme to just point to the default-exclude.js file.