### PR TITLE
chore: Isolate coverage reporting per package

### DIFF
--- a/monorepo-merge-reports.js
+++ b/monorepo-merge-reports.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const rimraf = require('rimraf');
+const makeDir = require('make-dir');
+const glob = require('glob');
+
+process.chdir(__dirname);
+rimraf.sync('.nyc_output');
+makeDir.sync('.nyc_output');
+// Merge coverage data from each package so we can generate a complete report
+glob.sync('packages/*/.nyc_output').forEach(nycOutput => {
+    const { status, stderr } = spawnSync(
+        'nyc',
+        [
+            'merge',
+            nycOutput,
+            path.join(
+                '.nyc_output',
+                path.basename(path.dirname(nycOutput)) + '.json'
+            )
+        ],
+        { encoding: 'utf8' }
+    );
+
+    if (status !== 0) {
+        console.error(stderr);
+        process.exit(status);
+    }
+});

--- a/monorepo-per-package-nycrc.json
+++ b/monorepo-per-package-nycrc.json
@@ -1,0 +1,6 @@
+{
+	"all": true,
+	"reporter": [
+		"none"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "monorepo containing the various nuts and bolts that facilitate istanbul.js test instrumentation",
   "scripts": {
-    "posttest": "eslint .",
-    "test": "cross-env LERNA_TEST_RUN=1 NODE_ENV=test nyc lerna --ignore nyc exec npm test",
+    "pretest": "eslint .",
+    "test": "cross-env LERNA_TEST_RUN=1 NODE_ENV=test lerna --ignore nyc exec npm test",
+    "posttest": "node ./monorepo-merge-reports.js && nyc report",
     "postinstall": "lerna bootstrap --hoist",
     "release": "lerna publish --conventional-commits --dist-tag=next"
   },
@@ -33,26 +34,16 @@
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.13.0",
+    "glob": "^7.1.3",
     "lerna": "^3.13.4",
     "nyc": "^14.1.0",
     "prettier": "^1.17.0"
   },
   "nyc": {
-    "exclude": [
-      "**/bin/**",
-      "**/coverage/**",
-      "**/dist/**",
-      "**/html/assets/**",
-      "**/html-spa/assets/**",
-      "**/html-spa/src/**",
-      "**/html-spa/rollup.config.js",
-      "**/test/**"
-    ],
     "reporter": [
       "text",
       "lcov"
-    ],
-    "all": true
+    ]
   },
   "engines": {
     "node": ">=6"

--- a/packages/istanbul-lib-coverage/package.json
+++ b/packages/istanbul-lib-coverage/package.json
@@ -9,11 +9,12 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.0"
   },
   "karmaDeps": {
     "browserify-istanbul": "^0.2.1",

--- a/packages/istanbul-lib-hook/package.json
+++ b/packages/istanbul-lib-hook/package.json
@@ -9,14 +9,15 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "dependencies": {
     "append-transform": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "release": "babel src --out-dir dist && documentation build -f md -o api.md src",
-    "test": "mocha --require=@babel/register",
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json --require=@babel/register --include=src mocha",
     "prepublish": "npm run release"
   },
   "dependencies": {
@@ -32,7 +32,8 @@
     "documentation": "^11.0.0",
     "js-yaml": "^3.13.1",
     "mocha": "^6.1.4",
-    "nopt": "^4.0.1"
+    "nopt": "^4.0.1",
+    "nyc": "^14.1.0"
   },
   "license": "BSD-3-Clause",
   "bugs": {

--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "dependencies": {
     "istanbul-lib-coverage": "^2.0.5",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.1.4",
+    "nyc": "^14.1.0",
     "rimraf": "^2.6.3"
   },
   "license": "BSD-3-Clause",

--- a/packages/istanbul-lib-source-maps/package.json
+++ b/packages/istanbul-lib-source-maps/package.json
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "dependencies": {
     "debug": "^4.1.1",
@@ -21,6 +21,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.1.4",
+    "nyc": "^14.1.0",
     "ts-node": "^8.1.0"
   },
   "license": "BSD-3-Clause",

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha --recursive",
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha --recursive",
     "prepare": "rollup --config lib/html-spa/rollup.config.js"
   },
   "dependencies": {
@@ -24,6 +24,7 @@
     "istanbul-lib-report": "^2.0.8",
     "is-windows": "^1.0.2",
     "mocha": "^6.1.4",
+    "nyc": "^14.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "rollup": "^1.11.0",
@@ -46,6 +47,15 @@
     "url": "https://github.com/istanbuljs/istanbuljs/issues"
   },
   "homepage": "https://istanbul.js.org/",
+  "nyc": {
+    "exclude": [
+      "lib/html/assets/**",
+      "lib/html-spa/assets/**",
+      "lib/html-spa/src/**",
+      "lib/html-spa/rollup.config.js",
+      "test/**"
+    ]
+  },
   "engines": {
     "node": ">=6"
   }

--- a/packages/nyc-config-hook-run-in-this-context/package.json
+++ b/packages/nyc-config-hook-run-in-this-context/package.json
@@ -7,7 +7,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,11 @@
   },
   "dependencies": {
     "semver": "^6.0.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.0"
   },
   "engines": {
     "node": ">=6"

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -7,7 +7,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,8 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "nyc": "^14.1.0"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Test coverage should only count if we're directly testing the result of
something.  This runs nyc per package then produces combined reporting.

---

This effectively drops coverage from istanbul-api because I want to avoid any further commits to that package (other than deleting it).  This commit was part of #396 but I want to push it ahead.

This causes the reported coverage to drop significantly but this is more valid.