### PR TITLE
chore: Export class from lib/context.js

### DIFF
--- a/packages/istanbul-lib-report/index.js
+++ b/packages/istanbul-lib-report/index.js
@@ -9,7 +9,7 @@
  */
 
 const summarizer = require('./lib/summarizer');
-const context = require('./lib/context');
+const Context = require('./lib/context');
 const watermarks = require('./lib/watermarks');
 
 module.exports = {
@@ -19,7 +19,7 @@ module.exports = {
      * @returns {Context}
      */
     createContext(opts) {
-        return context.create(opts);
+        return new Context(opts);
     },
     /**
      * returns the default watermarks that would be used when not

--- a/packages/istanbul-lib-report/lib/context.js
+++ b/packages/istanbul-lib-report/lib/context.js
@@ -125,8 +125,4 @@ Object.defineProperty(Context.prototype, 'writer', {
     }
 });
 
-module.exports = {
-    create(opts) {
-        return new Context(opts);
-    }
-};
+module.exports = Context;

--- a/packages/istanbul-lib-report/test/context.test.js
+++ b/packages/istanbul-lib-report/test/context.test.js
@@ -1,11 +1,11 @@
 /* globals describe, it */
 
 const assert = require('chai').assert;
-const context = require('../lib/context');
+const Context = require('../lib/context');
 
 describe('context', () => {
     it('provides a writer when not specified', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         const w = ctx.writer;
 
         assert.ok(w);
@@ -13,23 +13,23 @@ describe('context', () => {
         assert.ok(w === ctx.getWriter());
     });
     it('returns an XML writer', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         const w = ctx.writer;
         const cw = w.writeFile(null);
         assert.ok(ctx.getXMLWriter(cw));
     });
     it('returns source text by default', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         const file = __filename;
         assert.ok(ctx.getSource(file));
     });
     it('throws when source file not found', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         const file = __filename;
         assert.throws(ctx.getSource.bind(ctx, file + '.xxx'));
     });
     it('provides the correct classes for default watermarks', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         assert.equal(ctx.classForPercent('statements', 49), 'low');
         assert.equal(ctx.classForPercent('branches', 50), 'medium');
         assert.equal(ctx.classForPercent('functions', 80), 'high');
@@ -42,14 +42,14 @@ describe('context', () => {
             branches: [10],
             lines: [90, 95]
         };
-        const ctx = context.create({ watermarks: w });
+        const ctx = new Context({ watermarks: w });
         assert.equal(ctx.classForPercent('statements', 49), 'low');
         assert.equal(ctx.classForPercent('branches', 50), 'medium');
         assert.equal(ctx.classForPercent('functions', 80), 'high');
         assert.equal(ctx.classForPercent('lines', 85), 'low');
     });
     it('returns a visitor', () => {
-        const ctx = context.create();
+        const ctx = new Context();
         const visitor = ctx.getVisitor({});
         assert.ok(typeof visitor.onStart === 'function');
     });


### PR DESCRIPTION
This was done as part of breaking API changes I'm making in istanbul-lib-report, decided to pull this out as a separate PR for easy review.  This is itself a non-breaking change as lib/context.js is not a public interface.