### PR TITLE
feat!: Refactor istanbul-lib-report so report can choose summarizer

### DIFF
--- a/packages/istanbul-lib-report/index.js
+++ b/packages/istanbul-lib-report/index.js
@@ -8,7 +8,6 @@
  * @module Exports
  */
 
-const summarizer = require('./lib/summarizer');
 const Context = require('./lib/context');
 const watermarks = require('./lib/watermarks');
 
@@ -31,26 +30,4 @@ module.exports = {
     getDefaultWatermarks() {
         return watermarks.getDefault();
     }
-};
-/**
- * standard summary functions
- */
-module.exports.summarizers = {
-    /**
-     * a summarizer that creates a flat tree with one root node and bunch of
-     * files directly under it
-     */
-    flat: summarizer.createFlatSummary,
-    /**
-     * a summarizer that creates a hierarchical tree where the coverage summaries
-     * of each directly reflect the summaries of all subdirectories and files in it
-     */
-    nested: summarizer.createNestedSummary,
-    /**
-     * a summarizer that creates a tree in which directories are not nested.
-     * Every subdirectory is a child of the root node and only reflects the
-     * coverage numbers for the files in it (i.e. excludes subdirectories).
-     * This is the default summarizer.
-     */
-    pkg: summarizer.createPackageSummary
 };

--- a/packages/istanbul-lib-report/index.js
+++ b/packages/istanbul-lib-report/index.js
@@ -10,6 +10,7 @@
 
 const Context = require('./lib/context');
 const watermarks = require('./lib/watermarks');
+const ReportBase = require('./lib/report-base');
 
 module.exports = {
     /**
@@ -20,6 +21,7 @@ module.exports = {
     createContext(opts) {
         return new Context(opts);
     },
+
     /**
      * returns the default watermarks that would be used when not
      * overridden
@@ -29,5 +31,10 @@ module.exports = {
      */
     getDefaultWatermarks() {
         return watermarks.getDefault();
-    }
+    },
+
+    /**
+     * Base class for all reports
+     */
+    ReportBase
 };

--- a/packages/istanbul-lib-report/lib/context.js
+++ b/packages/istanbul-lib-report/lib/context.js
@@ -8,6 +8,7 @@ const FileWriter = require('./file-writer');
 const XMLWriter = require('./xml-writer');
 const tree = require('./tree');
 const watermarks = require('./watermarks');
+const SummarizerFactory = require('./summarizer-factory');
 
 function defaultSourceLookup(path) {
     try {
@@ -41,10 +42,13 @@ function normalizeWatermarks(specified = {}) {
  */
 class Context {
     constructor(opts) {
-        opts = opts || {};
         this.dir = opts.dir || 'coverage';
         this.watermarks = normalizeWatermarks(opts.watermarks);
         this.sourceFinder = opts.sourceFinder || defaultSourceLookup;
+        this._summarizerFactory = new SummarizerFactory(
+            opts.coverageMap,
+            opts.defaultSummarizer
+        );
         this.data = {};
     }
 
@@ -108,6 +112,10 @@ class Context {
      */
     getVisitor(partialVisitor) {
         return new tree.Visitor(partialVisitor);
+    }
+
+    getTree(name = 'defaultSummarizer') {
+        return this._summarizerFactory[name];
     }
 }
 

--- a/packages/istanbul-lib-report/lib/report-base.js
+++ b/packages/istanbul-lib-report/lib/report-base.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// TODO: switch to class private field when targetting node.js 12
+const _summarizer = Symbol('ReportBase.#summarizer');
+
+class ReportBase {
+    constructor(summarizer) {
+        this[_summarizer] = summarizer;
+    }
+
+    execute(context) {
+        context.getTree(this[_summarizer]).visit(this, context);
+    }
+}
+
+module.exports = ReportBase;

--- a/packages/istanbul-lib-report/test/context.test.js
+++ b/packages/istanbul-lib-report/test/context.test.js
@@ -3,10 +3,15 @@
 
 const assert = require('chai').assert;
 const Context = require('../lib/context');
+const coverageMap = require('./helpers/coverage-map');
+
+const optsEmptyCoverage = {
+    coverageMap: coverageMap.empty
+};
 
 describe('context', () => {
     it('provides a writer when not specified', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         const w = ctx.writer;
 
         assert.ok(w);
@@ -14,23 +19,23 @@ describe('context', () => {
         assert.ok(w === ctx.getWriter());
     });
     it('returns an XML writer', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         const w = ctx.writer;
         const cw = w.writeFile(null);
         assert.ok(ctx.getXMLWriter(cw));
     });
     it('returns source text by default', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         const file = __filename;
         assert.ok(ctx.getSource(file));
     });
     it('throws when source file not found', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         const file = __filename;
         assert.throws(ctx.getSource.bind(ctx, file + '.xxx'));
     });
     it('provides the correct classes for default watermarks', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         assert.equal(ctx.classForPercent('statements', 49), 'low');
         assert.equal(ctx.classForPercent('branches', 50), 'medium');
         assert.equal(ctx.classForPercent('functions', 80), 'high');
@@ -38,19 +43,22 @@ describe('context', () => {
         assert.equal(ctx.classForPercent('xlines', 85), 'unknown');
     });
     it('allows watermark overrides', () => {
-        const w = {
+        const watermarks = {
             statements: {},
             branches: [10],
             lines: [90, 95]
         };
-        const ctx = new Context({ watermarks: w });
+        const ctx = new Context({
+            watermarks,
+            coverageMap: coverageMap.empty
+        });
         assert.equal(ctx.classForPercent('statements', 49), 'low');
         assert.equal(ctx.classForPercent('branches', 50), 'medium');
         assert.equal(ctx.classForPercent('functions', 80), 'high');
         assert.equal(ctx.classForPercent('lines', 85), 'low');
     });
     it('returns a visitor', () => {
-        const ctx = new Context();
+        const ctx = new Context(optsEmptyCoverage);
         const visitor = ctx.getVisitor({});
         assert.ok(typeof visitor.onStart === 'function');
     });

--- a/packages/istanbul-lib-report/test/helpers/coverage-map.js
+++ b/packages/istanbul-lib-report/test/helpers/coverage-map.js
@@ -28,86 +28,55 @@ function makeCoverage(filePath, numStatements, numCovered) {
     return fc;
 }
 
-function protoDir(dir) {
-    const files = ['constructor.js', 'toString.js'];
+function filesMap(dir, files) {
+    dir = dir ? dir + '/' : '';
+
     let count = 0;
-    const map = {};
-    files.forEach(f => {
-        const filePath = dir ? dir + '/' + f : f;
-        const fc = makeCoverage(filePath, 4, count);
-        count += 1;
-        map[filePath] = fc;
-    });
-    return coverage.createCoverageMap(map);
+
+    return coverage.createCoverageMap(
+        files.reduce((map, file) => {
+            const filePath = dir + file;
+            map[filePath] = makeCoverage(filePath, 4, count);
+            count += 1;
+
+            return map;
+        }, {})
+    );
+}
+
+function protoDir(dir) {
+    return filesMap(dir, ['constructor.js', 'toString.js']);
 }
 
 function singleDir(dir) {
-    const files = ['file3.js', 'file4.js', 'file2.js', 'file1.js'];
-    let count = 0;
-    const map = {};
-    files.forEach(f => {
-        const filePath = dir ? dir + '/' + f : f;
-        const fc = makeCoverage(filePath, 4, count);
-        count += 1;
-        map[filePath] = fc;
-    });
-    return coverage.createCoverageMap(map);
+    return filesMap(dir, ['file3.js', 'file4.js', 'file2.js', 'file1.js']);
 }
 
 function twoDir(nested) {
-    const files = nested
-        ? [
-              'lib1/file3.js',
-              'lib1/lib2/file4.js',
-              'lib1/file2.js',
-              'lib1/lib2/file1.js'
-          ]
-        : ['lib1/file3.js', 'lib2/file4.js', 'lib1/file2.js', 'lib2/file1.js'];
-    let count = 0;
-    const map = {};
-    files.forEach(f => {
-        const filePath = f;
-        const fc = makeCoverage(filePath, 4, count);
-        count += 1;
-        map[filePath] = fc;
-    });
-    return coverage.createCoverageMap(map);
+    return filesMap('', [
+        'lib1/file3.js',
+        nested ? 'lib1/lib2/file4.js' : 'lib2/file4.js',
+        'lib1/file2.js',
+        nested ? 'lib1/lib2/file1.js' : 'lib2/file1.js'
+    ]);
 }
 
 function threeDir() {
-    const files = [
+    return filesMap('', [
         'lib1/file3.js',
         'lib2/file4.js',
         'lib1/sub/dir/file2.js',
         'file1.js'
-    ];
-    let count = 0;
-    const map = {};
-    files.forEach(f => {
-        const filePath = f;
-        const fc = makeCoverage(filePath, 4, count);
-        count += 1;
-        map[filePath] = fc;
-    });
-    return coverage.createCoverageMap(map);
+    ]);
 }
 
 function multiDir() {
-    const files = [
+    return filesMap('', [
         'lib1/sub/file3.js',
         'lib1/file4.js',
         'lib2/sub1/file2.js',
         'lib2/sub2/file1.js'
-    ];
-    let count = 0;
-    const map = {};
-    files.forEach(f => {
-        const filePath = f;
-        const fc = makeCoverage(filePath, 4, count);
-        count += 1;
-        map[filePath] = fc;
-    });
-    return coverage.createCoverageMap(map);
+    ]);
 }
 
 module.exports = {

--- a/packages/istanbul-lib-report/test/helpers/coverage-map.js
+++ b/packages/istanbul-lib-report/test/helpers/coverage-map.js
@@ -1,0 +1,118 @@
+const coverage = require('istanbul-lib-coverage');
+
+function makeCoverage(filePath, numStatements, numCovered) {
+    const fc = {
+        path: filePath,
+        statementMap: {},
+        fnMap: {},
+        branchMap: {},
+        s: {},
+        f: {},
+        b: {}
+    };
+    let i;
+    let index;
+
+    for (i = 0; i < numStatements; i += 1) {
+        index = i + 1;
+        fc.statementMap[index] = {
+            start: { line: i + 1, column: 0 },
+            end: { line: i + 1, column: 100 }
+        };
+        if (i < numCovered) {
+            fc.s[index] = 1;
+        }
+    }
+    return fc;
+}
+
+function protoDir(dir) {
+    const files = ['constructor.js', 'toString.js'];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = dir ? dir + '/' + f : f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
+function singleDir(dir) {
+    const files = ['file3.js', 'file4.js', 'file2.js', 'file1.js'];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = dir ? dir + '/' + f : f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
+function twoDir(nested) {
+    const files = nested
+        ? [
+              'lib1/file3.js',
+              'lib1/lib2/file4.js',
+              'lib1/file2.js',
+              'lib1/lib2/file1.js'
+          ]
+        : ['lib1/file3.js', 'lib2/file4.js', 'lib1/file2.js', 'lib2/file1.js'];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
+function threeDir() {
+    const files = [
+        'lib1/file3.js',
+        'lib2/file4.js',
+        'lib1/sub/dir/file2.js',
+        'file1.js'
+    ];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
+function multiDir() {
+    const files = [
+        'lib1/sub/file3.js',
+        'lib1/file4.js',
+        'lib2/sub1/file2.js',
+        'lib2/sub2/file1.js'
+    ];
+    let count = 0;
+    const map = {};
+    files.forEach(f => {
+        const filePath = f;
+        const fc = makeCoverage(filePath, 4, count);
+        count += 1;
+        map[filePath] = fc;
+    });
+    return coverage.createCoverageMap(map);
+}
+
+module.exports = {
+    empty: coverage.createCoverageMap({}),
+    protoDir,
+    singleDir,
+    twoDir,
+    threeDir,
+    multiDir
+};

--- a/packages/istanbul-lib-report/test/helpers/coverage-map.js
+++ b/packages/istanbul-lib-report/test/helpers/coverage-map.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const coverage = require('istanbul-lib-coverage');
 
 function makeCoverage(filePath, numStatements, numCovered) {

--- a/packages/istanbul-lib-report/test/index.test.js
+++ b/packages/istanbul-lib-report/test/index.test.js
@@ -8,10 +8,6 @@ describe('report interface', () => {
     it('exports the desired interface', () => {
         assert.isFunction(index.createContext);
         assert.isFunction(index.getDefaultWatermarks);
-        assert.isObject(index.summarizers);
-        assert.isFunction(index.summarizers.flat);
-        assert.isFunction(index.summarizers.nested);
-        assert.isFunction(index.summarizers.pkg);
     });
     it('exposes default watermarks', () => {
         const w = index.getDefaultWatermarks();
@@ -24,8 +20,5 @@ describe('report interface', () => {
             },
             w
         );
-    });
-    it('creates a context without options', () => {
-        assert.ok(index.createContext());
     });
 });

--- a/packages/istanbul-reports/lib/clover/index.js
+++ b/packages/istanbul-reports/lib/clover/index.js
@@ -3,11 +3,150 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-function CloverReport(opts) {
-    this.cw = null;
-    this.xml = null;
-    this.projectRoot = opts.projectRoot || process.cwd();
-    this.file = opts.file || 'clover.xml';
+const { ReportBase } = require('istanbul-lib-report');
+
+class CloverReport extends ReportBase {
+    constructor(opts) {
+        super();
+
+        this.cw = null;
+        this.xml = null;
+        this.projectRoot = opts.projectRoot || process.cwd();
+        this.file = opts.file || 'clover.xml';
+    }
+
+    onStart(root, context) {
+        this.cw = context.writer.writeFile(this.file);
+        this.xml = context.getXMLWriter(this.cw);
+        this.writeRootStats(root, context);
+    }
+
+    onEnd() {
+        this.xml.closeAll();
+        this.cw.close();
+    }
+
+    getTreeStats(node, context) {
+        const state = {
+            packages: 0,
+            files: 0,
+            classes: 0
+        };
+        const visitor = {
+            onSummary(node, state) {
+                const metrics = node.getCoverageSummary(true);
+                if (metrics) {
+                    state.packages += 1;
+                }
+            },
+            onDetail(node, state) {
+                state.classes += 1;
+                state.files += 1;
+            }
+        };
+        node.visit(context.getVisitor(visitor), state);
+        return state;
+    }
+
+    writeRootStats(node, context) {
+        this.cw.println('<?xml version="1.0" encoding="UTF-8"?>');
+        this.xml.openTag('coverage', {
+            generated: Date.now().toString(),
+            clover: '3.2.0'
+        });
+
+        this.xml.openTag('project', {
+            timestamp: Date.now().toString(),
+            name: 'All files'
+        });
+
+        const metrics = node.getCoverageSummary();
+        this.xml.inlineTag('metrics', {
+            statements: metrics.lines.total,
+            coveredstatements: metrics.lines.covered,
+            conditionals: metrics.branches.total,
+            coveredconditionals: metrics.branches.covered,
+            methods: metrics.functions.total,
+            coveredmethods: metrics.functions.covered,
+            elements:
+                metrics.lines.total +
+                metrics.branches.total +
+                metrics.functions.total,
+            coveredelements:
+                metrics.lines.covered +
+                metrics.branches.covered +
+                metrics.functions.covered,
+            complexity: 0,
+            loc: metrics.lines.total,
+            ncloc: metrics.lines.total, // what? copied as-is from old report
+            ...this.getTreeStats(node, context)
+        });
+    }
+
+    writeMetrics(metrics) {
+        this.xml.inlineTag('metrics', {
+            statements: metrics.lines.total,
+            coveredstatements: metrics.lines.covered,
+            conditionals: metrics.branches.total,
+            coveredconditionals: metrics.branches.covered,
+            methods: metrics.functions.total,
+            coveredmethods: metrics.functions.covered
+        });
+    }
+
+    onSummary(node) {
+        if (node.isRoot()) {
+            return;
+        }
+        const metrics = node.getCoverageSummary(true);
+        if (!metrics) {
+            return;
+        }
+
+        this.xml.openTag('package', {
+            name: asJavaPackage(node)
+        });
+        this.writeMetrics(metrics);
+    }
+
+    onSummaryEnd(node) {
+        if (node.isRoot()) {
+            return;
+        }
+        this.xml.closeTag('package');
+    }
+
+    onDetail(node) {
+        const fileCoverage = node.getFileCoverage();
+        const metrics = node.getCoverageSummary();
+        const branchByLine = fileCoverage.getBranchCoverageByLine();
+
+        this.xml.openTag('file', {
+            name: asClassName(node),
+            path: fileCoverage.path
+        });
+
+        this.writeMetrics(metrics);
+
+        const lines = fileCoverage.getLineCoverage();
+        Object.entries(lines).forEach(([k, count]) => {
+            const attrs = {
+                num: k,
+                count,
+                type: 'stmt'
+            };
+            const branchDetail = branchByLine[k];
+
+            if (branchDetail) {
+                attrs.type = 'cond';
+                attrs.truecount = branchDetail.covered;
+                attrs.falsecount = branchDetail.total - branchDetail.covered;
+            }
+            this.xml.inlineTag('line', attrs);
+        });
+
+        this.xml.closeTag('file');
+    }
 }
 
 function asJavaPackage(node) {
@@ -21,138 +160,5 @@ function asJavaPackage(node) {
 function asClassName(node) {
     return node.getRelativeName().replace(/.*[\\/]/, '');
 }
-
-CloverReport.prototype.onStart = function(root, context) {
-    this.cw = context.writer.writeFile(this.file);
-    this.xml = context.getXMLWriter(this.cw);
-    this.writeRootStats(root, context);
-};
-
-CloverReport.prototype.onEnd = function() {
-    this.xml.closeAll();
-    this.cw.close();
-};
-
-CloverReport.prototype.getTreeStats = function(node, context) {
-    const state = {
-        packages: 0,
-        files: 0,
-        classes: 0
-    };
-    const visitor = {
-        onSummary(node, state) {
-            const metrics = node.getCoverageSummary(true);
-            if (metrics) {
-                state.packages += 1;
-            }
-        },
-        onDetail(node, state) {
-            state.classes += 1;
-            state.files += 1;
-        }
-    };
-    node.visit(context.getVisitor(visitor), state);
-    return state;
-};
-
-CloverReport.prototype.writeRootStats = function(node, context) {
-    this.cw.println('<?xml version="1.0" encoding="UTF-8"?>');
-    this.xml.openTag('coverage', {
-        generated: Date.now().toString(),
-        clover: '3.2.0'
-    });
-
-    this.xml.openTag('project', {
-        timestamp: Date.now().toString(),
-        name: 'All files'
-    });
-
-    const metrics = node.getCoverageSummary();
-    this.xml.inlineTag('metrics', {
-        statements: metrics.lines.total,
-        coveredstatements: metrics.lines.covered,
-        conditionals: metrics.branches.total,
-        coveredconditionals: metrics.branches.covered,
-        methods: metrics.functions.total,
-        coveredmethods: metrics.functions.covered,
-        elements:
-            metrics.lines.total +
-            metrics.branches.total +
-            metrics.functions.total,
-        coveredelements:
-            metrics.lines.covered +
-            metrics.branches.covered +
-            metrics.functions.covered,
-        complexity: 0,
-        loc: metrics.lines.total,
-        ncloc: metrics.lines.total, // what? copied as-is from old report
-        ...this.getTreeStats(node, context)
-    });
-};
-
-CloverReport.prototype.writeMetrics = function(metrics) {
-    this.xml.inlineTag('metrics', {
-        statements: metrics.lines.total,
-        coveredstatements: metrics.lines.covered,
-        conditionals: metrics.branches.total,
-        coveredconditionals: metrics.branches.covered,
-        methods: metrics.functions.total,
-        coveredmethods: metrics.functions.covered
-    });
-};
-
-CloverReport.prototype.onSummary = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
-    const metrics = node.getCoverageSummary(true);
-    if (!metrics) {
-        return;
-    }
-
-    this.xml.openTag('package', {
-        name: asJavaPackage(node)
-    });
-    this.writeMetrics(metrics);
-};
-
-CloverReport.prototype.onSummaryEnd = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
-    this.xml.closeTag('package');
-};
-
-CloverReport.prototype.onDetail = function(node) {
-    const fileCoverage = node.getFileCoverage();
-    const metrics = node.getCoverageSummary();
-    const branchByLine = fileCoverage.getBranchCoverageByLine();
-
-    this.xml.openTag('file', {
-        name: asClassName(node),
-        path: fileCoverage.path
-    });
-
-    this.writeMetrics(metrics);
-
-    const lines = fileCoverage.getLineCoverage();
-    Object.entries(lines).forEach(([k, count]) => {
-        const attrs = {
-            num: k,
-            count,
-            type: 'stmt'
-        };
-        const branchDetail = branchByLine[k];
-
-        if (branchDetail) {
-            attrs.type = 'cond';
-            attrs.truecount = branchDetail.covered;
-            attrs.falsecount = branchDetail.total - branchDetail.covered;
-        }
-        this.xml.inlineTag('line', attrs);
-    });
-
-    this.xml.closeTag('file');
-};
 
 module.exports = CloverReport;

--- a/packages/istanbul-reports/lib/cobertura/index.js
+++ b/packages/istanbul-reports/lib/cobertura/index.js
@@ -4,11 +4,134 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 const path = require('path');
-function CoberturaReport(opts) {
-    this.cw = null;
-    this.xml = null;
-    this.projectRoot = opts.projectRoot || process.cwd();
-    this.file = opts.file || 'cobertura-coverage.xml';
+const { ReportBase } = require('istanbul-lib-report');
+
+class CoberturaReport extends ReportBase {
+    constructor(opts) {
+        super();
+
+        this.cw = null;
+        this.xml = null;
+        this.projectRoot = opts.projectRoot || process.cwd();
+        this.file = opts.file || 'cobertura-coverage.xml';
+    }
+
+    onStart(root, context) {
+        this.cw = context.writer.writeFile(this.file);
+        this.xml = context.getXMLWriter(this.cw);
+        this.writeRootStats(root);
+    }
+
+    onEnd() {
+        this.xml.closeAll();
+        this.cw.close();
+    }
+
+    writeRootStats(node) {
+        const metrics = node.getCoverageSummary();
+        this.cw.println('<?xml version="1.0" ?>');
+        this.cw.println(
+            '<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">'
+        );
+        this.xml.openTag('coverage', {
+            'lines-valid': metrics.lines.total,
+            'lines-covered': metrics.lines.covered,
+            'line-rate': metrics.lines.pct / 100.0,
+            'branches-valid': metrics.branches.total,
+            'branches-covered': metrics.branches.covered,
+            'branch-rate': metrics.branches.pct / 100.0,
+            timestamp: Date.now().toString(),
+            complexity: '0',
+            version: '0.1'
+        });
+        this.xml.openTag('sources');
+        this.xml.inlineTag('source', null, this.projectRoot);
+        this.xml.closeTag('sources');
+        this.xml.openTag('packages');
+    }
+
+    onSummary(node) {
+        if (node.isRoot()) {
+            return;
+        }
+        const metrics = node.getCoverageSummary(true);
+        if (!metrics) {
+            return;
+        }
+        this.xml.openTag('package', {
+            name: asJavaPackage(node),
+            'line-rate': metrics.lines.pct / 100.0,
+            'branch-rate': metrics.branches.pct / 100.0
+        });
+        this.xml.openTag('classes');
+    }
+
+    onSummaryEnd(node) {
+        if (node.isRoot()) {
+            return;
+        }
+        this.xml.closeTag('classes');
+        this.xml.closeTag('package');
+    }
+
+    onDetail(node) {
+        const fileCoverage = node.getFileCoverage();
+        const metrics = node.getCoverageSummary();
+        const branchByLine = fileCoverage.getBranchCoverageByLine();
+
+        this.xml.openTag('class', {
+            name: asClassName(node),
+            filename: path.relative(this.projectRoot, fileCoverage.path),
+            'line-rate': metrics.lines.pct / 100.0,
+            'branch-rate': metrics.branches.pct / 100.0
+        });
+
+        this.xml.openTag('methods');
+        const fnMap = fileCoverage.fnMap;
+        Object.entries(fnMap).forEach(([k, { name, decl }]) => {
+            const hits = fileCoverage.f[k];
+            this.xml.openTag('method', {
+                name,
+                hits,
+                signature: '()V' //fake out a no-args void return
+            });
+            this.xml.openTag('lines');
+            //Add the function definition line and hits so that jenkins cobertura plugin records method hits
+            this.xml.inlineTag('line', {
+                number: decl.start.line,
+                hits
+            });
+            this.xml.closeTag('lines');
+            this.xml.closeTag('method');
+        });
+        this.xml.closeTag('methods');
+
+        this.xml.openTag('lines');
+        const lines = fileCoverage.getLineCoverage();
+        Object.entries(lines).forEach(([k, hits]) => {
+            const attrs = {
+                number: k,
+                hits,
+                branch: 'false'
+            };
+            const branchDetail = branchByLine[k];
+
+            if (branchDetail) {
+                attrs.branch = true;
+                attrs['condition-coverage'] =
+                    branchDetail.coverage +
+                    '% (' +
+                    branchDetail.covered +
+                    '/' +
+                    branchDetail.total +
+                    ')';
+            }
+            this.xml.inlineTag('line', attrs);
+        });
+
+        this.xml.closeTag('lines');
+        this.xml.closeTag('class');
+    }
 }
 
 function asJavaPackage(node) {
@@ -22,122 +145,5 @@ function asJavaPackage(node) {
 function asClassName(node) {
     return node.getRelativeName().replace(/.*[\\/]/, '');
 }
-
-CoberturaReport.prototype.onStart = function(root, context) {
-    this.cw = context.writer.writeFile(this.file);
-    this.xml = context.getXMLWriter(this.cw);
-    this.writeRootStats(root);
-};
-
-CoberturaReport.prototype.onEnd = function() {
-    this.xml.closeAll();
-    this.cw.close();
-};
-
-CoberturaReport.prototype.writeRootStats = function(node) {
-    const metrics = node.getCoverageSummary();
-    this.cw.println('<?xml version="1.0" ?>');
-    this.cw.println(
-        '<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">'
-    );
-    this.xml.openTag('coverage', {
-        'lines-valid': metrics.lines.total,
-        'lines-covered': metrics.lines.covered,
-        'line-rate': metrics.lines.pct / 100.0,
-        'branches-valid': metrics.branches.total,
-        'branches-covered': metrics.branches.covered,
-        'branch-rate': metrics.branches.pct / 100.0,
-        timestamp: Date.now().toString(),
-        complexity: '0',
-        version: '0.1'
-    });
-    this.xml.openTag('sources');
-    this.xml.inlineTag('source', null, this.projectRoot);
-    this.xml.closeTag('sources');
-    this.xml.openTag('packages');
-};
-
-CoberturaReport.prototype.onSummary = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
-    const metrics = node.getCoverageSummary(true);
-    if (!metrics) {
-        return;
-    }
-    this.xml.openTag('package', {
-        name: asJavaPackage(node),
-        'line-rate': metrics.lines.pct / 100.0,
-        'branch-rate': metrics.branches.pct / 100.0
-    });
-    this.xml.openTag('classes');
-};
-
-CoberturaReport.prototype.onSummaryEnd = function(node) {
-    if (node.isRoot()) {
-        return;
-    }
-    this.xml.closeTag('classes');
-    this.xml.closeTag('package');
-};
-
-CoberturaReport.prototype.onDetail = function(node) {
-    const fileCoverage = node.getFileCoverage();
-    const metrics = node.getCoverageSummary();
-    const branchByLine = fileCoverage.getBranchCoverageByLine();
-
-    this.xml.openTag('class', {
-        name: asClassName(node),
-        filename: path.relative(this.projectRoot, fileCoverage.path),
-        'line-rate': metrics.lines.pct / 100.0,
-        'branch-rate': metrics.branches.pct / 100.0
-    });
-
-    this.xml.openTag('methods');
-    const fnMap = fileCoverage.fnMap;
-    Object.entries(fnMap).forEach(([k, { name, decl }]) => {
-        const hits = fileCoverage.f[k];
-        this.xml.openTag('method', {
-            name,
-            hits,
-            signature: '()V' //fake out a no-args void return
-        });
-        this.xml.openTag('lines');
-        //Add the function definition line and hits so that jenkins cobertura plugin records method hits
-        this.xml.inlineTag('line', {
-            number: decl.start.line,
-            hits
-        });
-        this.xml.closeTag('lines');
-        this.xml.closeTag('method');
-    });
-    this.xml.closeTag('methods');
-
-    this.xml.openTag('lines');
-    const lines = fileCoverage.getLineCoverage();
-    Object.entries(lines).forEach(([k, hits]) => {
-        const attrs = {
-            number: k,
-            hits,
-            branch: 'false'
-        };
-        const branchDetail = branchByLine[k];
-
-        if (branchDetail) {
-            attrs.branch = true;
-            attrs['condition-coverage'] =
-                branchDetail.coverage +
-                '% (' +
-                branchDetail.covered +
-                '/' +
-                branchDetail.total +
-                ')';
-        }
-        this.xml.inlineTag('line', attrs);
-    });
-
-    this.xml.closeTag('lines');
-    this.xml.closeTag('class');
-};
 
 module.exports = CoberturaReport;

--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -5,6 +5,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { ReportBase } = require('istanbul-lib-report');
 const HtmlReport = require('../html');
 
 const standardLinkMapper = {
@@ -36,8 +37,10 @@ const standardLinkMapper = {
     }
 };
 
-class HtmlSpaReport {
+class HtmlSpaReport extends ReportBase {
     constructor(opts = {}) {
+        super();
+
         this.verbose = opts.verbose || false;
         this.linkMapper = opts.linkMapper || standardLinkMapper;
         this.subdir = opts.subdir || '';

--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -6,6 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const handlebars = require('handlebars').create();
+const { ReportBase } = require('istanbul-lib-report');
 const annotator = require('./annotator');
 const helpers = require('./helpers');
 const templateFor = function(name) {
@@ -108,8 +109,10 @@ function fixPct(metrics) {
     return metrics;
 }
 
-class HtmlReport {
+class HtmlReport extends ReportBase {
     constructor(opts) {
+        super();
+
         this.verbose = opts.verbose;
         this.linkMapper = opts.linkMapper || standardLinkMapper;
         this.subdir = opts.subdir || '';

--- a/packages/istanbul-reports/lib/json/index.js
+++ b/packages/istanbul-reports/lib/json/index.js
@@ -3,37 +3,42 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const { ReportBase } = require('istanbul-lib-report');
 
-function JsonReport(opts) {
-    this.file = opts.file || 'coverage-final.json';
-    this.first = true;
-}
+class JsonReport extends ReportBase {
+    constructor(opts) {
+        super();
 
-JsonReport.prototype.onStart = function(root, context) {
-    this.contentWriter = context.writer.writeFile(this.file);
-    this.contentWriter.write('{');
-};
-
-JsonReport.prototype.onDetail = function(node) {
-    const fc = node.getFileCoverage();
-    const key = fc.path;
-    const cw = this.contentWriter;
-
-    if (this.first) {
-        this.first = false;
-    } else {
-        cw.write(',');
+        this.file = opts.file || 'coverage-final.json';
+        this.first = true;
     }
-    cw.write(JSON.stringify(key));
-    cw.write(': ');
-    cw.write(JSON.stringify(fc));
-    cw.println('');
-};
 
-JsonReport.prototype.onEnd = function() {
-    const cw = this.contentWriter;
-    cw.println('}');
-    cw.close();
-};
+    onStart(root, context) {
+        this.contentWriter = context.writer.writeFile(this.file);
+        this.contentWriter.write('{');
+    }
+
+    onDetail(node) {
+        const fc = node.getFileCoverage();
+        const key = fc.path;
+        const cw = this.contentWriter;
+
+        if (this.first) {
+            this.first = false;
+        } else {
+            cw.write(',');
+        }
+        cw.write(JSON.stringify(key));
+        cw.write(': ');
+        cw.write(JSON.stringify(fc));
+        cw.println('');
+    }
+
+    onEnd() {
+        const cw = this.contentWriter;
+        cw.println('}');
+        cw.close();
+    }
+}
 
 module.exports = JsonReport;

--- a/packages/istanbul-reports/lib/lcov/index.js
+++ b/packages/istanbul-reports/lib/lcov/index.js
@@ -3,12 +3,17 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+const { ReportBase } = require('istanbul-lib-report');
 const LcovOnlyReport = require('../lcovonly');
 const HtmlReport = require('../html');
 
-function LcovReport() {
-    this.lcov = new LcovOnlyReport({ file: 'lcov.info' });
-    this.html = new HtmlReport({ subdir: 'lcov-report' });
+class LcovReport extends ReportBase {
+    constructor() {
+        super();
+
+        this.lcov = new LcovOnlyReport({ file: 'lcov.info' });
+        this.html = new HtmlReport({ subdir: 'lcov-report' });
+    }
 }
 
 ['Start', 'End', 'Summary', 'SummaryEnd', 'Detail'].forEach(what => {

--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -3,60 +3,64 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const { ReportBase } = require('istanbul-lib-report');
 
-function LcovOnlyReport(opts) {
-    this.file = opts.file || 'lcov.info';
-    this.contentWriter = null;
-}
+class LcovOnlyReport extends ReportBase {
+    constructor(opts) {
+        super();
+        this.file = opts.file || 'lcov.info';
+        this.contentWriter = null;
+    }
 
-LcovOnlyReport.prototype.onStart = function(root, context) {
-    this.contentWriter = context.writer.writeFile(this.file);
-};
+    onStart(root, context) {
+        this.contentWriter = context.writer.writeFile(this.file);
+    }
 
-LcovOnlyReport.prototype.onDetail = function(node) {
-    const fc = node.getFileCoverage();
-    const writer = this.contentWriter;
-    const functions = fc.f;
-    const functionMap = fc.fnMap;
-    const lines = fc.getLineCoverage();
-    const branches = fc.b;
-    const branchMap = fc.branchMap;
-    const summary = node.getCoverageSummary();
+    onDetail(node) {
+        const fc = node.getFileCoverage();
+        const writer = this.contentWriter;
+        const functions = fc.f;
+        const functionMap = fc.fnMap;
+        const lines = fc.getLineCoverage();
+        const branches = fc.b;
+        const branchMap = fc.branchMap;
+        const summary = node.getCoverageSummary();
 
-    writer.println('TN:'); //no test name
-    writer.println('SF:' + fc.path);
+        writer.println('TN:'); //no test name
+        writer.println('SF:' + fc.path);
 
-    Object.values(functionMap).forEach(meta => {
-        writer.println('FN:' + [meta.decl.start.line, meta.name].join(','));
-    });
-    writer.println('FNF:' + summary.functions.total);
-    writer.println('FNH:' + summary.functions.covered);
-
-    Object.entries(functionMap).forEach(([key, meta]) => {
-        const stats = functions[key];
-        writer.println('FNDA:' + [stats, meta.name].join(','));
-    });
-
-    Object.entries(lines).forEach(entry => {
-        writer.println('DA:' + entry.join(','));
-    });
-    writer.println('LF:' + summary.lines.total);
-    writer.println('LH:' + summary.lines.covered);
-
-    Object.entries(branches).forEach(([key, branchArray]) => {
-        const meta = branchMap[key];
-        const { line } = meta.loc.start;
-        branchArray.forEach((b, i) => {
-            writer.println('BRDA:' + [line, key, i, b].join(','));
+        Object.values(functionMap).forEach(meta => {
+            writer.println('FN:' + [meta.decl.start.line, meta.name].join(','));
         });
-    });
-    writer.println('BRF:' + summary.branches.total);
-    writer.println('BRH:' + summary.branches.covered);
-    writer.println('end_of_record');
-};
+        writer.println('FNF:' + summary.functions.total);
+        writer.println('FNH:' + summary.functions.covered);
 
-LcovOnlyReport.prototype.onEnd = function() {
-    this.contentWriter.close();
-};
+        Object.entries(functionMap).forEach(([key, meta]) => {
+            const stats = functions[key];
+            writer.println('FNDA:' + [stats, meta.name].join(','));
+        });
+
+        Object.entries(lines).forEach(entry => {
+            writer.println('DA:' + entry.join(','));
+        });
+        writer.println('LF:' + summary.lines.total);
+        writer.println('LH:' + summary.lines.covered);
+
+        Object.entries(branches).forEach(([key, branchArray]) => {
+            const meta = branchMap[key];
+            const { line } = meta.loc.start;
+            branchArray.forEach((b, i) => {
+                writer.println('BRDA:' + [line, key, i, b].join(','));
+            });
+        });
+        writer.println('BRF:' + summary.branches.total);
+        writer.println('BRH:' + summary.branches.covered);
+        writer.println('end_of_record');
+    }
+
+    onEnd() {
+        this.contentWriter.close();
+    }
+}
 
 module.exports = LcovOnlyReport;

--- a/packages/istanbul-reports/lib/none/index.js
+++ b/packages/istanbul-reports/lib/none/index.js
@@ -3,6 +3,8 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-function NoneReport() {}
+const { ReportBase } = require('istanbul-lib-report');
+
+class NoneReport extends ReportBase {}
 
 module.exports = NoneReport;

--- a/packages/istanbul-reports/lib/teamcity/index.js
+++ b/packages/istanbul-reports/lib/teamcity/index.js
@@ -3,11 +3,55 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const { ReportBase } = require('istanbul-lib-report');
 
-function TeamcityReport(opts) {
-    opts = opts || {};
-    this.file = opts.file || null;
-    this.blockName = opts.blockName || 'Code Coverage Summary';
+class TeamcityReport extends ReportBase {
+    constructor(opts) {
+        super();
+
+        opts = opts || {};
+        this.file = opts.file || null;
+        this.blockName = opts.blockName || 'Code Coverage Summary';
+    }
+
+    onStart(node, context) {
+        const metrics = node.getCoverageSummary();
+        const cw = context.writer.writeFile(this.file);
+
+        cw.println('');
+        cw.println("##teamcity[blockOpened name='" + this.blockName + "']");
+
+        //Statements Covered
+        cw.println(
+            lineForKey(metrics.statements.covered, 'CodeCoverageAbsBCovered')
+        );
+        cw.println(
+            lineForKey(metrics.statements.total, 'CodeCoverageAbsBTotal')
+        );
+
+        //Branches Covered
+        cw.println(
+            lineForKey(metrics.branches.covered, 'CodeCoverageAbsRCovered')
+        );
+        cw.println(lineForKey(metrics.branches.total, 'CodeCoverageAbsRTotal'));
+
+        //Functions Covered
+        cw.println(
+            lineForKey(metrics.functions.covered, 'CodeCoverageAbsMCovered')
+        );
+        cw.println(
+            lineForKey(metrics.functions.total, 'CodeCoverageAbsMTotal')
+        );
+
+        //Lines Covered
+        cw.println(
+            lineForKey(metrics.lines.covered, 'CodeCoverageAbsLCovered')
+        );
+        cw.println(lineForKey(metrics.lines.total, 'CodeCoverageAbsLTotal'));
+
+        cw.println("##teamcity[blockClosed name='" + this.blockName + "']");
+        cw.close();
+    }
 }
 
 function lineForKey(value, teamcityVar) {
@@ -19,36 +63,5 @@ function lineForKey(value, teamcityVar) {
         "']"
     );
 }
-
-TeamcityReport.prototype.onStart = function(node, context) {
-    const metrics = node.getCoverageSummary();
-    const cw = context.writer.writeFile(this.file);
-
-    cw.println('');
-    cw.println("##teamcity[blockOpened name='" + this.blockName + "']");
-
-    //Statements Covered
-    cw.println(
-        lineForKey(metrics.statements.covered, 'CodeCoverageAbsBCovered')
-    );
-    cw.println(lineForKey(metrics.statements.total, 'CodeCoverageAbsBTotal'));
-
-    //Branches Covered
-    cw.println(lineForKey(metrics.branches.covered, 'CodeCoverageAbsRCovered'));
-    cw.println(lineForKey(metrics.branches.total, 'CodeCoverageAbsRTotal'));
-
-    //Functions Covered
-    cw.println(
-        lineForKey(metrics.functions.covered, 'CodeCoverageAbsMCovered')
-    );
-    cw.println(lineForKey(metrics.functions.total, 'CodeCoverageAbsMTotal'));
-
-    //Lines Covered
-    cw.println(lineForKey(metrics.lines.covered, 'CodeCoverageAbsLCovered'));
-    cw.println(lineForKey(metrics.lines.total, 'CodeCoverageAbsLTotal'));
-
-    cw.println("##teamcity[blockClosed name='" + this.blockName + "']");
-    cw.close();
-};
 
 module.exports = TeamcityReport;

--- a/packages/istanbul-reports/lib/text-lcov/index.js
+++ b/packages/istanbul-reports/lib/text-lcov/index.js
@@ -3,13 +3,14 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-const util = require('util');
 const LcovOnly = require('../lcovonly');
 
-function TextLcov(opts) {
-    opts.file = '-';
-    LcovOnly.call(this, opts);
+class TextLcov extends LcovOnly {
+    constructor(opts) {
+        super(opts);
+
+        opts.file = '-';
+    }
 }
 
-util.inherits(TextLcov, LcovOnly);
 module.exports = TextLcov;

--- a/packages/istanbul-reports/lib/text-summary/index.js
+++ b/packages/istanbul-reports/lib/text-summary/index.js
@@ -3,10 +3,38 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const { ReportBase } = require('istanbul-lib-report');
 
-function TextSummaryReport(opts) {
-    opts = opts || {};
-    this.file = opts.file || null;
+class TextSummaryReport extends ReportBase {
+    constructor(opts) {
+        super();
+
+        opts = opts || {};
+        this.file = opts.file || null;
+    }
+
+    onStart(node, context) {
+        const summary = node.getCoverageSummary();
+        const cw = context.writer.writeFile(this.file);
+        const printLine = function(key) {
+            const str = lineForKey(summary, key);
+            const clazz = context.classForPercent(key, summary[key].pct);
+            cw.println(cw.colorize(str, clazz));
+        };
+
+        cw.println('');
+        cw.println(
+            '=============================== Coverage summary ==============================='
+        );
+        printLine('statements');
+        printLine('branches');
+        printLine('functions');
+        printLine('lines');
+        cw.println(
+            '================================================================================'
+        );
+        cw.close();
+    }
 }
 
 function lineForKey(summary, key) {
@@ -30,28 +58,5 @@ function lineForKey(summary, key) {
     }
     return result;
 }
-
-TextSummaryReport.prototype.onStart = function(node, context) {
-    const summary = node.getCoverageSummary();
-    const cw = context.writer.writeFile(this.file);
-    const printLine = function(key) {
-        const str = lineForKey(summary, key);
-        const clazz = context.classForPercent(key, summary[key].pct);
-        cw.println(cw.colorize(str, clazz));
-    };
-
-    cw.println('');
-    cw.println(
-        '=============================== Coverage summary ==============================='
-    );
-    printLine('statements');
-    printLine('branches');
-    printLine('functions');
-    printLine('lines');
-    cw.println(
-        '================================================================================'
-    );
-    cw.close();
-};
 
 module.exports = TextSummaryReport;

--- a/packages/istanbul-reports/test/cobertura-regression.js
+++ b/packages/istanbul-reports/test/cobertura-regression.js
@@ -6,11 +6,11 @@ const istanbulLibCoverage = require('istanbul-lib-coverage');
 const Report = require('../lib/cobertura');
 
 it('issue 384', () => {
-    const coverageMap = istanbulLibCoverage.createCoverageMap({});
-    const tree = istanbulLibReport.summarizers.pkg(coverageMap);
     const context = istanbulLibReport.createContext({
-        dir: './'
+        dir: './',
+        coverageMap: istanbulLibCoverage.createCoverageMap({})
     });
+    const tree = context.getTree('pkg');
     const report = new Report({ file: '-' });
 
     FileWriter.startCapture();

--- a/packages/istanbul-reports/test/html-spa/index.js
+++ b/packages/istanbul-reports/test/html-spa/index.js
@@ -54,13 +54,12 @@ describe('html-spa', () => {
             __dirname,
             '../fixtures/specs/' + file
         ));
-        const tree = istanbulLibReport.summarizers.nested(
-            istanbulLibCoverage.createCoverageMap(fixture.map)
-        );
         it(fixture.title, () => {
             const context = istanbulLibReport.createContext({
-                dir: './'
+                dir: './',
+                coverageMap: istanbulLibCoverage.createCoverageMap(fixture.map)
             });
+            const tree = context.getTree('nested');
             const report = new HtmlSpaReport(fixture.opts);
             tree.visit(report, context);
 

--- a/packages/istanbul-reports/test/text/index.js
+++ b/packages/istanbul-reports/test/text/index.js
@@ -26,18 +26,16 @@ describe('TextReport', () => {
             __dirname,
             '../fixtures/specs/' + file
         ));
-        fixture.map = istanbulLibReport.summarizers.pkg(
-            istanbulLibCoverage.createCoverageMap(fixture.map)
-        );
         it(fixture.title, function() {
             if (isWindows()) {
                 // appveyor does not render console color.
                 return this.skip();
             }
             const context = istanbulLibReport.createContext({
-                dir: './'
+                dir: './',
+                coverageMap: istanbulLibCoverage.createCoverageMap(fixture.map)
             });
-            const tree = fixture.map;
+            const tree = context.getTree('pkg');
             const report = new TextReport(fixture.opts);
             tree.visit(report, context);
             const output = FileWriter.getOutput();


### PR DESCRIPTION
BREAKING CHANGE: This changes existing istanbul-lib-report API's.

Fixes #390

---

This is still WIP.  I feel like maybe istanbul-lib-report needs to define a base class for all reports to use, something which takes in options including a `defaultSummarizer` option.  The final API might be something where you create the reporting context, then for each report call `report.execute(context)`.  In this case the `execute` function would be defined in the base report class but could be overridden by specific reports (`html-spa` maybe?).

CC @lukeapage