### PR TITLE
chore: Enable eslint strict rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,8 +12,7 @@
         }
     },
     "parserOptions": {
-        "ecmaVersion": 7,
-        "sourceType": "module"
+        "ecmaVersion": 7
     },
     "env": {
         "es6": true,
@@ -25,6 +24,15 @@
     },
     "overrides": [
         {
+            "files": [
+                "packages/istanbul-lib-instrument/{bin,src,test}/**",
+                "packages/istanbul-reports/lib/html-spa/rollup.config.js"
+            ],
+            "parserOptions": {
+                "sourceType": "module"
+            }
+        },
+        {
             "files": "packages/istanbul-reports/lib/html/assets/**/*",
             "env": {
                 "browser": true
@@ -35,7 +43,6 @@
             "parser": "babel-eslint",
             "parserOptions": {
                 "ecmaVersion": 2019,
-                "sourceType": "module",
                 "ecmaFeatures": {
                     "jsx": true
                 }
@@ -59,7 +66,8 @@
                 "prefer-arrow-callback": "error",
                 "prefer-const": "error",
                 "prefer-rest-params": "error",
-                "prefer-spread": "error"
+                "prefer-spread": "error",
+                "strict": "error"
             }
         }
     ]

--- a/packages/istanbul-lib-coverage/test/coverage-map.test.js
+++ b/packages/istanbul-lib-coverage/test/coverage-map.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-coverage/test/index.test.js
+++ b/packages/istanbul-lib-coverage/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-hook/index.js
+++ b/packages/istanbul-lib-hook/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-hook/lib/hook.js
+++ b/packages/istanbul-lib-hook/lib/hook.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-hook/test/data/baz.js
+++ b/packages/istanbul-lib-hook/test/data/baz.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
     baz() {
         return 'baz';

--- a/packages/istanbul-lib-hook/test/data/foo.js
+++ b/packages/istanbul-lib-hook/test/data/foo.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
     foo() {
         return 'foo';

--- a/packages/istanbul-lib-hook/test/data/matcher/general/general.js
+++ b/packages/istanbul-lib-hook/test/data/matcher/general/general.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function() {
     return 42;
 };

--- a/packages/istanbul-lib-hook/test/data/matcher/lib/lib-top.js
+++ b/packages/istanbul-lib-hook/test/data/matcher/lib/lib-top.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function() {
     return 42;
 };

--- a/packages/istanbul-lib-hook/test/data/matcher/top.js
+++ b/packages/istanbul-lib-hook/test/data/matcher/top.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function() {
     return 32;
 };

--- a/packages/istanbul-lib-hook/test/hook.test.js
+++ b/packages/istanbul-lib-hook/test/hook.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach, afterEach */
 const assert = require('chai').assert;
 const hook = require('../lib/hook');

--- a/packages/istanbul-lib-hook/test/index.test.js
+++ b/packages/istanbul-lib-hook/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-instrument/test/util/guards.js
+++ b/packages/istanbul-lib-instrument/test/util/guards.js
@@ -42,7 +42,6 @@ export function isObjectSpreadAvailable() {
 }
 
 export function isObjectFreezeAvailable() {
-    'use strict';
     if (!Object.freeze) {
         return false;
     }

--- a/packages/istanbul-lib-report/lib/context.js
+++ b/packages/istanbul-lib-report/lib/context.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-report/lib/file-writer.js
+++ b/packages/istanbul-lib-report/lib/file-writer.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-report/lib/watermarks.js
+++ b/packages/istanbul-lib-report/lib/watermarks.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-report/lib/xml-writer.js
+++ b/packages/istanbul-lib-report/lib/xml-writer.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-lib-report/test/context.test.js
+++ b/packages/istanbul-lib-report/test/context.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-report/test/file-writer.test.js
+++ b/packages/istanbul-lib-report/test/file-writer.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach, afterEach */
 
 const fs = require('fs');

--- a/packages/istanbul-lib-report/test/index.test.js
+++ b/packages/istanbul-lib-report/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-report/test/path.test.js
+++ b/packages/istanbul-lib-report/test/path.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach, afterEach */
 
 const path = require('path');

--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-report/test/tree.test.js
+++ b/packages/istanbul-lib-report/test/tree.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-report/test/xml-writer.test.js
+++ b/packages/istanbul-lib-report/test/xml-writer.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-source-maps/test/index.test.js
+++ b/packages/istanbul-lib-source-maps/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 const assert = require('chai').assert;
 const index = require('../index');

--- a/packages/istanbul-lib-source-maps/test/map-store.test.js
+++ b/packages/istanbul-lib-source-maps/test/map-store.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 const path = require('path');
 const assert = require('chai').assert;

--- a/packages/istanbul-lib-source-maps/test/mapped.test.js
+++ b/packages/istanbul-lib-source-maps/test/mapped.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 const assert = require('chai').assert;
 const MappedCoverage = require('../lib/mapped').MappedCoverage;

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 const path = require('path');
 const assert = require('chai').assert;

--- a/packages/istanbul-reports/index.js
+++ b/packages/istanbul-reports/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/clover/index.js
+++ b/packages/istanbul-reports/lib/clover/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/cobertura/index.js
+++ b/packages/istanbul-reports/lib/cobertura/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/html/helpers.js
+++ b/packages/istanbul-reports/lib/html/helpers.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/html/insertion-text.js
+++ b/packages/istanbul-reports/lib/html/insertion-text.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/lcov/index.js
+++ b/packages/istanbul-reports/lib/lcov/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/none/index.js
+++ b/packages/istanbul-reports/lib/none/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/lib/text-lcov/index.js
+++ b/packages/istanbul-reports/lib/text-lcov/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /*
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/packages/istanbul-reports/test/cobertura-regression.js
+++ b/packages/istanbul-reports/test/cobertura-regression.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals it */
 const FileWriter = require('istanbul-lib-report/lib/file-writer');
 const istanbulLibReport = require('istanbul-lib-report');

--- a/packages/istanbul-reports/test/html-spa/index.js
+++ b/packages/istanbul-reports/test/html-spa/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, afterEach, before, after */
 const fs = require('fs');
 const path = require('path');

--- a/packages/istanbul-reports/test/html/annotator.js
+++ b/packages/istanbul-reports/test/html/annotator.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it */
 const fs = require('fs');
 const istanbulLibCoverage = require('istanbul-lib-coverage');

--- a/packages/istanbul-reports/test/html/insertion-text.test.js
+++ b/packages/istanbul-reports/test/html/insertion-text.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach */
 const assert = require('chai').assert;
 const InsertionText = require('../../lib/html/insertion-text');

--- a/packages/istanbul-reports/test/text/index.js
+++ b/packages/istanbul-reports/test/text/index.js
@@ -1,3 +1,4 @@
+'use strict';
 /* globals describe, it, beforeEach, before, after */
 const fs = require('fs');
 const path = require('path');

--- a/packages/nyc-config-hook-run-in-this-context/test/index.test.js
+++ b/packages/nyc-config-hook-run-in-this-context/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global describe, it */
 
 const assert = require('chai').assert;

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global describe, it */
 
 const path = require('path');


### PR DESCRIPTION
* Moving `"sourceType": "module"` into an override ensures it does not suppress the `strict` rule for non-ESM files.
* The `strict` rule is applied everything else except html report assets (stuff copied directly to the browser).  I don't feel like dealing with the risk that this breaks some odd browser.