### PR TITLE
feat: ignore files under test"s" directories by default

### DIFF
--- a/packages/test-exclude/default-exclude.js
+++ b/packages/test-exclude/default-exclude.js
@@ -4,8 +4,8 @@ const devConfigs = ['ava', 'babel', 'jest', 'nyc', 'rollup', 'webpack'];
 
 module.exports = [
     'coverage/**',
-    'packages/*/test/**',
-    'test/**',
+    'packages/*/test{,s}/**',
+    'test{,s}/**',
     'test{,-*}.{js,cjs,mjs,ts}',
     '**/*{.,-}test.{js,cjs,mjs,ts}',
     '**/__tests__/**',

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -43,6 +43,16 @@ describe('testExclude', () => {
             .should.equal(false);
     });
 
+    it('ignores ./test and ./tests', () => {
+        exclude()
+            .shouldInstrument('./test/index.js')
+            .should.equal(false);
+
+        exclude()
+            .shouldInstrument('./tests/index.js')
+            .should.equal(false);
+    });
+
     it('matches files in root with **/', () => {
         exclude()
             .shouldInstrument('__tests__/**')
@@ -227,8 +237,8 @@ describe('testExclude', () => {
     it('exports defaultExclude', () => {
         exclude.defaultExclude.should.deep.equal([
             'coverage/**',
-            'packages/*/test/**',
-            'test/**',
+            'packages/*/test{,s}/**',
+            'test{,s}/**',
             'test{,-*}.{js,cjs,mjs,ts}',
             '**/*{.,-}test.{js,cjs,mjs,ts}',
             '**/__tests__/**',


### PR DESCRIPTION
I often use the name `tests` rather than `test` when the directory contains multiple test files.
