### PR TITLE
fix(win32): Detect files on different drive as outside project

### DIFF
--- a/packages/test-exclude/index.js
+++ b/packages/test-exclude/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const glob = require('glob');
 const minimatch = require('minimatch');
 const defaultExclude = require('./default-exclude');
+const isOutsideDir = require('./is-outside-dir');
 
 class TestExclude {
     constructor(opts) {
@@ -93,7 +94,7 @@ class TestExclude {
             relFile = relFile || path.relative(this.cwd, filename);
 
             // Don't instrument files that are outside of the current working directory.
-            if (/^\.\./.test(path.relative(this.cwd, filename))) {
+            if (isOutsideDir(this.cwd, filename)) {
                 return false;
             }
 

--- a/packages/test-exclude/is-outside-dir-posix.js
+++ b/packages/test-exclude/is-outside-dir-posix.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function(dir, filename) {
+    return /^\.\./.test(path.relative(dir, filename));
+};

--- a/packages/test-exclude/is-outside-dir-win32.js
+++ b/packages/test-exclude/is-outside-dir-win32.js
@@ -6,9 +6,5 @@ const minimatch = require('minimatch');
 const dot = { dot: true };
 
 module.exports = function(dir, filename) {
-    return !minimatch(
-        path.resolve(dir, filename),
-        path.join(dir, '**'),
-        dot
-    );
+    return !minimatch(path.resolve(dir, filename), path.join(dir, '**'), dot);
 };

--- a/packages/test-exclude/is-outside-dir-win32.js
+++ b/packages/test-exclude/is-outside-dir-win32.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const path = require('path');
+const minimatch = require('minimatch');
+
+const dot = { dot: true };
+
+module.exports = function(dir, filename) {
+    return !minimatch(
+        path.resolve(dir, filename),
+        path.join(dir, '**'),
+        dot
+    );
+};

--- a/packages/test-exclude/is-outside-dir.js
+++ b/packages/test-exclude/is-outside-dir.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+
+// istanbul ignore next
+if (process.platform === 'win32') {
+    module.exports = require('./is-outside-dir-win32');
+} else {
+    module.exports = require('./is-outside-dir-posix');
+}

--- a/packages/test-exclude/is-outside-dir.js
+++ b/packages/test-exclude/is-outside-dir.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const path = require('path');
-
-// istanbul ignore next
 if (process.platform === 'win32') {
     module.exports = require('./is-outside-dir-win32');
 } else {

--- a/packages/test-exclude/nyc.config.js
+++ b/packages/test-exclude/nyc.config.js
@@ -9,6 +9,7 @@ module.exports = {
     ...base,
     exclude: [
         ...defaultExclude,
+        'is-outside-dir.js',
         isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js'
     ]
 };

--- a/packages/test-exclude/nyc.config.js
+++ b/packages/test-exclude/nyc.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const base = require('../../monorepo-per-package-nycrc.json');
+const defaultExclude = require('./default-exclude');
+
+const isWindows = process.platform === 'win32';
+
+module.exports = {
+    ...base,
+    exclude: [
+        ...defaultExclude,
+        isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js'
+    ]
+};

--- a/packages/test-exclude/package.json
+++ b/packages/test-exclude/package.json
@@ -4,10 +4,11 @@
   "description": "test for inclusion or exclusion of paths using globs",
   "main": "index.js",
   "files": [
-    "*.js"
+    "*.js",
+    "!nyc.config.js"
   ],
   "scripts": {
-    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
+    "test": "nyc mocha"
   },
   "repository": {
     "type": "git",

--- a/packages/test-exclude/test/test-exclude.js
+++ b/packages/test-exclude/test/test-exclude.js
@@ -63,6 +63,11 @@ describe('testExclude', () => {
         exclude({ include: ['../foo.js'] })
             .shouldInstrument('../foo.js')
             .should.equal(false);
+        if (process.platform === 'win32') {
+            exclude({ cwd: 'C:\\project' })
+                .shouldInstrument('D:\\project\\foo.js')
+                .should.equal(false);
+        }
     });
 
     it('can instrument files outside cwd if relativePath=false', () => {


### PR DESCRIPTION
Fixes #418