### PR TITLE
chore: Enforce complete coverage for test-exclude

### DIFF
--- a/packages/test-exclude/nyc.config.js
+++ b/packages/test-exclude/nyc.config.js
@@ -11,5 +11,10 @@ module.exports = {
         ...defaultExclude,
         'is-outside-dir.js',
         isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js'
-    ]
+    ],
+    checkCoverage: true,
+    lines: 100,
+    statements: 100,
+    functions: 100,
+    branches: 100
 };


### PR DESCRIPTION
PR is just so I can have travis run on Windows to verify 100% coverage.