### PR TITLE
fix: Set `opts.file = '-'` on text-lcov

### DIFF
--- a/packages/istanbul-reports/lib/text-lcov/index.js
+++ b/packages/istanbul-reports/lib/text-lcov/index.js
@@ -7,9 +7,10 @@ const LcovOnly = require('../lcovonly');
 
 class TextLcov extends LcovOnly {
     constructor(opts) {
-        super(opts);
-
-        opts.file = '-';
+        super({
+            ...opts,
+            file: '-'
+        });
     }
 }
 


### PR DESCRIPTION
Encountered this error in early testing of nyc against alpha release.  Note that setting `file: '-'` after `...opts` is intentional, the whole point of the text-lcov report is that it writes to stdout.  If a user wants the `opts.file` to be respected they need to use the `lcov-only` report.