### PR TITLE
Fix none report to not cause an exception

### DIFF
--- a/packages/istanbul-reports/lib/none/index.js
+++ b/packages/istanbul-reports/lib/none/index.js
@@ -5,6 +5,10 @@
  */
 const { ReportBase } = require('istanbul-lib-report');
 
-class NoneReport extends ReportBase {}
+class NoneReport extends ReportBase {
+    constructor() {
+        super();
+    }
+}
 
 module.exports = NoneReport;


### PR DESCRIPTION
the base class takes the default summarizer, so without this change it tries to pass an options object into the report base as a summarizer name.