### PR TITLE
Allow merge to work consistently on windows

### DIFF
--- a/monorepo-merge-reports.js
+++ b/monorepo-merge-reports.js
@@ -14,7 +14,7 @@ makeDir.sync('.nyc_output');
 // Merge coverage data from each package so we can generate a complete report
 glob.sync('packages/*/.nyc_output').forEach(nycOutput => {
     const { status, stderr } = spawnSync(
-        'nyc',
+        path.join('node_modules', '.bin', 'nyc'),
         [
             'merge',
             nycOutput,
@@ -23,7 +23,7 @@ glob.sync('packages/*/.nyc_output').forEach(nycOutput => {
                 path.basename(path.dirname(nycOutput)) + '.json'
             )
         ],
-        { encoding: 'utf8' }
+        { encoding: 'utf8', shell: true }
     );
 
     if (status !== 0) {


### PR DESCRIPTION
On windows, the default `npm test` doesn't work for me.. investigating I see no documentation that spawn sync works with running a command installed in a sub node_modules.

I'm not 100% sue, I just know that master doesn't work for me.

This issue was informative: https://github.com/nodejs/node/issues/8077