### PR TITLE
Force html-spa to always be nested

### DIFF
--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -39,7 +39,8 @@ const standardLinkMapper = {
 
 class HtmlSpaReport extends ReportBase {
     constructor(opts = {}) {
-        super();
+        // force the summarizer to nested for html-spa
+        super('nested');
 
         this.verbose = opts.verbose || false;
         this.linkMapper = opts.linkMapper || standardLinkMapper;


### PR DESCRIPTION
As previously discussed, this overrides the default summarizer so html-spa is always nested.