### PR TITLE
html-spa: Use empty per metric and make the overall the worst of all metrics

### DIFF
--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -93,7 +93,8 @@ class HtmlSpaReport extends ReportBase {
         this.htmlReport.onDetail(node, context);
     }
 
-    getMetric(metric, type, isEmpty, context) {
+    getMetric(metric, type, context) {
+        const isEmpty = metric.total === 0;
         return {
             total: metric.total,
             covered: metric.covered,
@@ -107,37 +108,28 @@ class HtmlSpaReport extends ReportBase {
 
     toDataStructure(node, context) {
         const coverageSummary = node.getCoverageSummary();
-        const isEmpty = coverageSummary.isEmpty();
         const metrics = {
             statements: this.getMetric(
                 coverageSummary.statements,
                 'statements',
-                isEmpty,
                 context
             ),
             branches: this.getMetric(
                 coverageSummary.branches,
                 'branches',
-                isEmpty,
                 context
             ),
             functions: this.getMetric(
                 coverageSummary.functions,
                 'functions',
-                isEmpty,
                 context
             ),
-            lines: this.getMetric(
-                coverageSummary.lines,
-                'lines',
-                isEmpty,
-                context
-            )
+            lines: this.getMetric(coverageSummary.lines, 'lines', context)
         };
 
         return {
             file: node.getRelativeName(),
-            isEmpty,
+            isEmpty: coverageSummary.isEmpty(),
             metrics,
             children:
                 node.isSummary() &&

--- a/packages/istanbul-reports/lib/html-spa/src/summaryTableLine.js
+++ b/packages/istanbul-reports/lib/html-spa/src/summaryTableLine.js
@@ -60,6 +60,33 @@ function FileCell({
     }
 }
 
+function getWorstMetricClassForPercent(metricsToShow, metrics) {
+    let classForPercent = 'none';
+    for (const metricToShow in metricsToShow) {
+        if (metricsToShow[metricToShow]) {
+            const metricClassForPercent = metrics[metricToShow].classForPercent;
+
+            // ignore none metrics so they don't change whats shown
+            if (metricClassForPercent === 'none') {
+                continue;
+            }
+
+            // if the metric low or lower than whats currently being used, replace it
+            if (
+                metricClassForPercent == 'low' ||
+                (metricClassForPercent === 'medium' &&
+                    classForPercent !== 'low') ||
+                (metricClassForPercent === 'high' &&
+                    classForPercent !== 'low' &&
+                    classForPercent !== 'medium')
+            ) {
+                classForPercent = metricClassForPercent;
+            }
+        }
+    }
+    return classForPercent;
+}
+
 module.exports = function SummaryTableLine({
     prefix,
     metrics,
@@ -81,7 +108,12 @@ module.exports = function SummaryTableLine({
     return (
         <>
             <tr>
-                <td className={'file ' + metrics.statements.classForPercent}>
+                <td
+                    className={
+                        'file ' +
+                        getWorstMetricClassForPercent(metricsToShow, metrics)
+                    }
+                >
                     {/* eslint-disable-line prefer-spread */ Array.apply(null, {
                         length: tabSize
                     }).map((nothing, index) => (

--- a/packages/istanbul-reports/test/fixtures/specs/maxcols.json
+++ b/packages/istanbul-reports/test/fixtures/specs/maxcols.json
@@ -20,15 +20,15 @@
                 "total": 0,
                 "covered": 0,
                 "skipped": 0,
-                "pct": 100,
-                "classForPercent": "high"
+                "pct": 0,
+                "classForPercent": "empty"
             },
             "functions": {
                 "total": 0,
                 "covered": 0,
                 "skipped": 0,
-                "pct": 100,
-                "classForPercent": "high"
+                "pct": 0,
+                "classForPercent": "empty"
             },
             "lines": {
                 "total": 18,
@@ -54,15 +54,15 @@
                         "total": 0,
                         "covered": 0,
                         "skipped": 0,
-                        "pct": 100,
-                        "classForPercent": "high"
+                        "pct": 0,
+                        "classForPercent": "empty"
                     },
                     "functions": {
                         "total": 0,
                         "covered": 0,
                         "skipped": 0,
-                        "pct": 100,
-                        "classForPercent": "high"
+                        "pct": 0,
+                        "classForPercent": "empty"
                     },
                     "lines": {
                         "total": 18,
@@ -80,206 +80,206 @@
         "/index.js": {
             "path": "/index.js",
             "statementMap": {
-              "0": {
-                "start": {
-                  "line": 1,
-                  "column": 15
+                "0": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 39
+                    }
                 },
-                "end": {
-                  "line": 1,
-                  "column": 39
-                }
-              },
-              "1": {
-                "start": {
-                  "line": 2,
-                  "column": 15
+                "1": {
+                    "start": {
+                        "line": 2,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 32
+                    }
                 },
-                "end": {
-                  "line": 2,
-                  "column": 32
-                }
-              },
-              "2": {
-                "start": {
-                  "line": 3,
-                  "column": 19
+                "2": {
+                    "start": {
+                        "line": 3,
+                        "column": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 40
+                    }
                 },
-                "end": {
-                  "line": 3,
-                  "column": 40
-                }
-              },
-              "3": {
-                "start": {
-                  "line": 4,
-                  "column": 13
+                "3": {
+                    "start": {
+                        "line": 4,
+                        "column": 13
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 28
+                    }
                 },
-                "end": {
-                  "line": 4,
-                  "column": 28
-                }
-              },
-              "4": {
-                "start": {
-                  "line": 5,
-                  "column": 18
+                "4": {
+                    "start": {
+                        "line": 5,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 40
+                    }
                 },
-                "end": {
-                  "line": 5,
-                  "column": 40
-                }
-              },
-              "5": {
-                "start": {
-                  "line": 9,
-                  "column": 2
+                "5": {
+                    "start": {
+                        "line": 9,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 11
+                    }
                 },
-                "end": {
-                  "line": 9,
-                  "column": 11
-                }
-              },
-              "6": {
-                "start": {
-                  "line": 13,
-                  "column": 2
+                "6": {
+                    "start": {
+                        "line": 13,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 19,
+                        "column": 10
+                    }
                 },
-                "end": {
-                  "line": 19,
-                  "column": 10
-                }
-              },
-              "7": {
-                "start": {
-                  "line": 21,
-                  "column": 2
+                "7": {
+                    "start": {
+                        "line": 21,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 81
+                    }
                 },
-                "end": {
-                  "line": 21,
-                  "column": 81
-                }
-              },
-              "8": {
-                "start": {
-                  "line": 21,
-                  "column": 40
+                "8": {
+                    "start": {
+                        "line": 21,
+                        "column": 40
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 81
+                    }
                 },
-                "end": {
-                  "line": 21,
-                  "column": 81
-                }
-              },
-              "9": {
-                "start": {
-                  "line": 22,
-                  "column": 2
+                "9": {
+                    "start": {
+                        "line": 22,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 69
+                    }
                 },
-                "end": {
-                  "line": 22,
-                  "column": 69
-                }
-              },
-              "10": {
-                "start": {
-                  "line": 22,
-                  "column": 40
+                "10": {
+                    "start": {
+                        "line": 22,
+                        "column": 40
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 69
+                    }
                 },
-                "end": {
-                  "line": 22,
-                  "column": 69
-                }
-              },
-              "11": {
-                "start": {
-                  "line": 24,
-                  "column": 2
+                "11": {
+                    "start": {
+                        "line": 24,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 26,
+                        "column": 3
+                    }
                 },
-                "end": {
-                  "line": 26,
-                  "column": 3
-                }
-              },
-              "12": {
-                "start": {
-                  "line": 25,
-                  "column": 4
+                "12": {
+                    "start": {
+                        "line": 25,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 25,
+                        "column": 63
+                    }
                 },
-                "end": {
-                  "line": 25,
-                  "column": 63
-                }
-              },
-              "13": {
-                "start": {
-                  "line": 28,
-                  "column": 2
+                "13": {
+                    "start": {
+                        "line": 28,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 30,
+                        "column": 3
+                    }
                 },
-                "end": {
-                  "line": 30,
-                  "column": 3
-                }
-              },
-              "14": {
-                "start": {
-                  "line": 29,
-                  "column": 4
+                "14": {
+                    "start": {
+                        "line": 29,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 29,
+                        "column": 54
+                    }
                 },
-                "end": {
-                  "line": 29,
-                  "column": 54
-                }
-              },
-              "15": {
-                "start": {
-                  "line": 32,
-                  "column": 2
+                "15": {
+                    "start": {
+                        "line": 32,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 36,
+                        "column": 3
+                    }
                 },
-                "end": {
-                  "line": 36,
-                  "column": 3
-                }
-              },
-              "16": {
-                "start": {
-                  "line": 33,
-                  "column": 4
+                "16": {
+                    "start": {
+                        "line": 33,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 57
+                    }
                 },
-                "end": {
-                  "line": 33,
-                  "column": 57
-                }
-              },
-              "17": {
-                "start": {
-                  "line": 35,
-                  "column": 4
+                "17": {
+                    "start": {
+                        "line": 35,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 35,
+                        "column": 24
+                    }
                 },
-                "end": {
-                  "line": 35,
-                  "column": 24
-                }
-              },
-              "18": {
-                "start": {
-                  "line": 38,
-                  "column": 2
+                "18": {
+                    "start": {
+                        "line": 38,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 40,
+                        "column": 3
+                    }
                 },
-                "end": {
-                  "line": 40,
-                  "column": 3
+                "19": {
+                    "start": {
+                        "line": 39,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 39,
+                        "column": 43
+                    }
                 }
-              },
-              "19": {
-                "start": {
-                  "line": 39,
-                  "column": 4
-                },
-                "end": {
-                  "line": 39,
-                  "column": 43
-                }
-              }
             },
             "fnMap": {},
             "branchMap": {},


### PR DESCRIPTION
I've been discussing some things with @tisgro who is much better at ui/ux than me (he is working on a PR to make html-spa much prettier) and we came to some conclusions about a few elements of the report.

Firstly - when you have a file with multiple lines and no branches - it might be 0% covered, but because branches is 0/0 it is shown green - this is pretty misleading as you might be led to thinking nothing needs to be done on that file. The empty class is only used on each individual metric when all the metrics are empty. So this changes that, so each metric can be empty and if its empty, its shown white - basically ignore me.

Secondly - the colour applied to the filename comes from the statements - which isn't even an included metric! even if it was lines, its confusing because filters don't work only on lines - they work on the worst of all shown metrics. So I've changed the filename color to be based on the worst metric that isn't empty - this makes the colouring match the filtering, so you won't see green files when filtering for low (we still have a confusing problem with folders, but I'll tackle that seperately).