### PR TITLE
Simplify the merge command

### DIFF
--- a/monorepo-merge-reports.js
+++ b/monorepo-merge-reports.js
@@ -14,7 +14,7 @@ makeDir.sync('.nyc_output');
 // Merge coverage data from each package so we can generate a complete report
 glob.sync('packages/*/.nyc_output').forEach(nycOutput => {
     const { status, stderr } = spawnSync(
-        path.join('node_modules', '.bin', 'nyc'),
+        'nyc',
         [
             'merge',
             nycOutput,


### PR DESCRIPTION
@coreyfarrell you left some comments on my merged PR: https://github.com/istanbuljs/istanbuljs/pull/429

1. Your right, the path join isn't needed. I must have added it first and the shell: true afterwards and not tried removing the original attempt

2. The command doesn't actually fail - I am not sure why but on windows it ends up with succeeding but with 0 coverage. If we look at a travis build on windows just before my pr was merged:
https://travis-ci.org/istanbuljs/istanbuljs/jobs/549497029

you'll see

```
> istanbuljs@2.0.0 posttest C:\Users\travis\build\istanbuljs\istanbuljs
> node ./monorepo-merge-reports.js && nyc report
lerna success exec Executed command in 10 packages: "npm test"
null
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |        0 |        0 |        0 |        0 |                   |
----------|----------|----------|----------|----------|-------------------|
The command "npm test" exited with 0.
```

I've re-confirmed that `shell: true` is needed on windows - if I revert it back it goes back to 0 coverage again. This PR cleans up the unnecessary path join.