### PR TITLE
chore: full test coverage for istanbul-lib-hook

### DIFF
--- a/monorepo-per-package-full.js
+++ b/monorepo-per-package-full.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+    ...require('./monorepo-per-package-nycrc'),
+    checkCoverage: true,
+    lines: 100,
+    statements: 100,
+    functions: 100,
+    branches: 100
+};

--- a/packages/istanbul-lib-hook/package.json
+++ b/packages/istanbul-lib-hook/package.json
@@ -9,7 +9,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha"
+    "test": "nyc --nycrc-path=../../monorepo-per-package-full.js mocha"
   },
   "dependencies": {
     "append-transform": "^1.0.0"

--- a/packages/istanbul-lib-hook/test/hook.test.js
+++ b/packages/istanbul-lib-hook/test/hook.test.js
@@ -207,6 +207,34 @@ describe('hooks', () => {
             );
             assert.equal(s, 10);
         });
+        it('transfers coverageVar when not set globally', () => {
+            let s;
+            const vm = require('vm');
+            const scriptTransformer = function() {
+                return `(function () {
+                    fakeCoverageVar.success = true;
+                    return 42;
+                }());`;
+            };
+            /* this simulates all unit tests being run through vm.runInContext */
+            hook.hookRunInContext(matcher, scriptTransformer, {
+                coverageVariable: 'fakeCoverageVar'
+            });
+            s = vm.runInContext(
+                '(function () { return 10; }());',
+                vm.createContext({}),
+                '/bar/foo.js'
+            );
+            assert.equal(s, 42);
+            assert.deepEqual(global.fakeCoverageVar, { success: true });
+            hook.unhookRunInContext();
+            s = vm.runInContext(
+                '(function () { return 10; }());',
+                vm.createContext({}),
+                '/bar/foo.js'
+            );
+            assert.equal(s, 10);
+        });
         it('does not transform code with no filename', () => {
             const vm = require('vm');
             hook.hookRunInContext(matcher, scriptTransformer);

--- a/packages/test-exclude/nyc.config.js
+++ b/packages/test-exclude/nyc.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const base = require('../../monorepo-per-package-nycrc.json');
+const base = require('../../monorepo-per-package-full');
 const defaultExclude = require('./default-exclude');
 
 const isWindows = process.platform === 'win32';
@@ -11,10 +11,5 @@ module.exports = {
         ...defaultExclude,
         'is-outside-dir.js',
         isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js'
-    ],
-    checkCoverage: true,
-    lines: 100,
-    statements: 100,
-    functions: 100,
-    branches: 100
+    ]
 };


### PR DESCRIPTION
monorepo-per-package-full.js and changes to packages/test-exclude/nyc.config.js are also in #452.  Since these changes are identical I think the second PR to be merged should just drop those changes.  If not I'll fix the merge conflict.