### PR TITLE
fix: Drop unneeded coverage data from `nyc --all`

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -157,6 +157,15 @@ class FileCoverage {
      *  Note that the other object should have the same structure as this one (same file).
      */
     merge(other) {
+        if (other.all === true) {
+            return;
+        }
+
+        if (this.all === true) {
+            this.data = other.data;
+            return;
+        }
+
         Object.entries(other.s).forEach(([k, v]) => {
             this.data.s[k] += v;
         });
@@ -246,7 +255,8 @@ dataProperties(FileCoverage, [
     'branchMap',
     's',
     'f',
-    'b'
+    'b',
+    'all'
 ]);
 
 module.exports = {


### PR DESCRIPTION
Frequently users run `nyc --all` in a way that causes source files to be
transpiled for actual testing but not transpiled for `--all`.  This
produces incompatible coverage data and inconsistantly wrong reporting.

The work around here is to drop coverage produced by `--all` for any
file where we have coverage produced by actual test runs.  This ensures
that we prefer code that was transpiled in the way which tests actually
ran.

Fixes #123, #224, #260, #322, #413