### PR TITLE
Use path.posix.relative to fix paths when generating html reports on Windows

### DIFF
--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -94,7 +94,7 @@ const standardLinkMapper = {
     relativePath(source, target) {
         const targetPath = this.getPath(target);
         const sourcePath = path.dirname(this.getPath(source));
-        return path.relative(sourcePath, targetPath);
+        return path.posix.relative(sourcePath, targetPath);
     },
 
     assetPath(node, name) {


### PR DESCRIPTION
Documentation:
https://nodejs.org/api/path.html#path_windows_vs_posix
https://nodejs.org/api/path.html#path_path_posix

Fixes #195

Tested this locally and it works great.