### PR TITLE
chore: bump dependencies due to vulnerability

### DIFF
--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -14,7 +14,7 @@
     "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
   },
   "dependencies": {
-    "handlebars": "^4.1.2"
+    "handlebars": "^4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
Hey there,

It seems `npm audit` is reporting `handlebars<4.3.0` to be vulnerable as per
https://www.npmjs.com/advisories/1164
