### PR TITLE
feat: Add addInputSourceMapsSync and getSourceMapSync methods

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -105,7 +105,7 @@ class SourceMapTransformer {
 
         coverageMap.files().forEach(file => {
             const fc = coverageMap.fileCoverageFor(file);
-            const sourceMap = this.finder(file);
+            const sourceMap = this.finder(file, fc);
             if (!sourceMap) {
                 uniqueFiles[getUniqueKey(file)] = {
                     file,


### PR DESCRIPTION
This is in support of restricting the amount of code nyc needs in the
synchronous path.