### PR TITLE
chore: Relax the check for ast in readInitialCoverage

### DIFF
--- a/packages/istanbul-lib-instrument/src/read-coverage.js
+++ b/packages/istanbul-lib-instrument/src/read-coverage.js
@@ -4,11 +4,9 @@ import * as t from '@babel/types';
 import { defaults } from '@istanbuljs/schema';
 import { MAGIC_KEY, MAGIC_VALUE } from './constants';
 
-const astClass = parse('').constructor;
-
 function getAst(code) {
-    if (code && code.constructor === astClass) {
-        // Already a babel ast
+    if (typeof code === 'object' && typeof code.type === 'string') {
+        // Assume code is already a babel ast.
         return code;
     }
 


### PR DESCRIPTION
Matching the constructor fails if multiple copies of @babel/parser are
installed.