### PR TITLE
feat: Convert to async API

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -89,7 +89,7 @@ class SourceMapTransformer {
         return changes > 0;
     }
 
-    transform(coverageMap) {
+    async transform(coverageMap) {
         const uniqueFiles = {};
         const getMappedCoverage = file => {
             const key = getUniqueKey(file);
@@ -103,29 +103,31 @@ class SourceMapTransformer {
             return uniqueFiles[key].mappedCoverage;
         };
 
-        coverageMap.files().forEach(file => {
+        for (const file of coverageMap.files()) {
             const fc = coverageMap.fileCoverageFor(file);
-            const sourceMap = this.finder(file, fc);
-            if (!sourceMap) {
+            const sourceMap = await this.finder(file, fc);
+
+            if (sourceMap) {
+                const changed = this.processFile(
+                    fc,
+                    sourceMap,
+                    getMappedCoverage
+                );
+                if (!changed) {
+                    debug(`File [${file}] ignored, nothing could be mapped`);
+                }
+            } else {
                 uniqueFiles[getUniqueKey(file)] = {
                     file,
                     mappedCoverage: fc
                 };
-                return;
             }
-
-            const changed = this.processFile(fc, sourceMap, getMappedCoverage);
-            if (!changed) {
-                debug(`File [${file}] ignored, nothing could be mapped`);
-            }
-        });
+        }
 
         return libCoverage.createCoverageMap(getOutput(uniqueFiles));
     }
 }
 
 module.exports = {
-    create(finder, opts) {
-        return new SourceMapTransformer(finder, opts);
-    }
+    SourceMapTransformer
 };

--- a/packages/istanbul-lib-source-maps/test/map-store.test.js
+++ b/packages/istanbul-lib-source-maps/test/map-store.test.js
@@ -6,17 +6,17 @@ const libCoverage = require('istanbul-lib-coverage');
 const MapStore = require('../lib/map-store').MapStore;
 
 describe('map store', () => {
-    it('applies the inputSourceMap from the coverage object if available', () => {
+    it('applies the inputSourceMap from the coverage object if available', async () => {
         /* shint ignore:line */
         const mapStore = new MapStore({});
 
         const coverageMap = libCoverage.createCoverageMap(coverageData);
 
-        const transformed = mapStore.transformCoverage(coverageMap);
-        assert.isUndefined(transformed.map.data.constructor);
+        const transformed = await mapStore.transformCoverage(coverageMap);
+        assert.isUndefined(transformed.data.constructor);
 
         const transformedCoverage =
-            transformed.map.data[path.resolve('./test.ts')].data;
+            transformed.data[path.resolve('./test.ts')].data;
 
         assert.deepEqual(transformedCoverage.statementMap, {
             '0': {


### PR DESCRIPTION
BREAKING CHANGE: MapStore#transformCoverage is now async and returns a
the coverage data only.  The `sourceFinder` method is now async and
provided directly on the `MapStore` instance.

---

CC @SimenB I know you use this API in jest, any objections?  We're not yet upgrading to `source-map@0.7.x` but this will make that upgrade possible without further changes to the public API.  Moving the `sourceFinder` method from the result of transformCoverage to the class itself is not strictly needed but just seems correct.