### PR TITLE
fix: Add missing dependency on istanbul-lib-report

### DIFF
--- a/packages/istanbul-reports/index.js
+++ b/packages/istanbul-reports/index.js
@@ -12,6 +12,10 @@ module.exports = {
         try {
             Cons = require(path.join(__dirname, 'lib', name));
         } catch (e) {
+            if (e.code !== 'MODULE_NOT_FOUND') {
+                throw e;
+            }
+
             Cons = require(name);
         }
 

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -14,6 +14,7 @@
     "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
   },
   "dependencies": {
+    "istanbul-lib-report": "^3.0.0-alpha.1",
     "handlebars": "^4.4.2"
   },
   "devDependencies": {
@@ -24,7 +25,6 @@
     "chai": "^4.2.0",
     "is-windows": "^1.0.2",
     "istanbul-lib-coverage": "^3.0.0-alpha.1",
-    "istanbul-lib-report": "^3.0.0-alpha.1",
     "mocha": "^6.2.1",
     "nyc": "^14.1.1",
     "react": "^16.10.2",


### PR DESCRIPTION
Ref istanbuljs/nyc#1204