### PR TITLE
Fix html report due relative urls

### DIFF
--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -94,7 +94,7 @@ const standardLinkMapper = {
     relativePath(source, target) {
         const targetPath = this.getPath(target);
         const sourcePath = path.dirname(this.getPath(source));
-        return path.posix.relative(sourcePath, targetPath);
+        return path.posix.relative(sourcePath, targetPath).replace(/index\.html$/, '');
     },
 
     assetPath(node, name) {
@@ -132,7 +132,7 @@ class HtmlReport extends ReportBase {
         const linkPath = nodePath.map(ancestor => {
             const target = this.linkMapper.relativePath(node, ancestor);
             const name = ancestor.getRelativeName() || 'All files';
-            return '<a href="' + target + '">' + name + '</a>';
+            return '<a href="' + (target == '' ? '/' + name : target) + '">' + name + '</a>';
         });
 
         linkPath.reverse();

--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -132,7 +132,7 @@ class HtmlReport extends ReportBase {
         const linkPath = nodePath.map(ancestor => {
             const target = this.linkMapper.relativePath(node, ancestor);
             const name = ancestor.getRelativeName() || 'All files';
-            return '<a href="' + (target == '' ? '/' + name : target) + '">' + name + '</a>';
+            return '<a href="' + target + '">' + name + '</a>';
         });
 
         linkPath.reverse();

--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -94,7 +94,7 @@ const standardLinkMapper = {
     relativePath(source, target) {
         const targetPath = this.getPath(target);
         const sourcePath = path.dirname(this.getPath(source));
-        return path.posix.relative(sourcePath, targetPath).replace(/index\.html$/, '');
+        return sourcePath == '.' ? targetPath : path.posix.join(sourcePath.replace(/([^\/]+)/g, '..'), targetPath);
     },
 
     assetPath(node, name) {


### PR DESCRIPTION
- Fix missing images Windows because backslashes (missing path.posix in v2.2.5)
- Change folder link, removing '.index.html' because Chrome removes it.
- Fix breadcrumb folder url

The error is present in all versions, tested on istanbul-reports v2.2.5 and 3.0.0-alpha.1.

![fix-detail](https://user-images.githubusercontent.com/727991/68357630-f539bf00-00e3-11ea-827a-97da430f719e.png)


