### PR TITLE
fix: mappedCoverage.addStatement is not a function

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -119,7 +119,7 @@ class SourceMapTransformer {
             } else {
                 uniqueFiles[getUniqueKey(file)] = {
                     file,
-                    mappedCoverage: fc
+                    mappedCoverage: new MappedCoverage(fc)
                 };
             }
         }


### PR DESCRIPTION
When testing both original and transpiled sources it was possible for
mappedCoverage to be a FileCoverage instance when it needed to be a
MappedCoverage instance.

Fixes istanbuljs/nyc#940