### PR TITLE
fix:handlebars arbitrary code execution

### DIFF
--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -1,60 +1,60 @@
 {
-    "name": "istanbul-reports",
-    "version": "3.0.0-alpha.3",
-    "description": "istanbul reports",
-    "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
-    "main": "index.js",
-    "files": [
-        "index.js",
-        "lib"
-    ],
-    "scripts": {
-        "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha --recursive",
-        "prepare": "webpack --config lib/html-spa/webpack.config.js --mode production",
-        "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
-    },
-    "dependencies": {
-        "handlebars": "^4.5.2",
-        "istanbul-lib-report": "^3.0.0-alpha.1"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.6.2",
-        "@babel/preset-env": "^7.6.2",
-        "@babel/preset-react": "^7.0.0",
-        "babel-loader": "^8.0.6",
-        "chai": "^4.2.0",
-        "is-windows": "^1.0.2",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "mocha": "^6.2.1",
-        "nyc": "^14.1.1",
-        "react": "^16.10.2",
-        "react-dom": "^16.10.2",
-        "webpack": "^4.41.0",
-        "webpack-cli": "^3.3.9"
-    },
-    "license": "BSD-3-Clause",
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git",
-        "directory": "packages/istanbul-reports"
-    },
-    "keywords": [
-        "istanbul",
-        "reports"
-    ],
-    "bugs": {
-        "url": "https://github.com/istanbuljs/istanbuljs/issues"
-    },
-    "homepage": "https://istanbul.js.org/",
-    "nyc": {
-        "exclude": [
-            "lib/html/assets/**",
-            "lib/html-spa/assets/**",
-            "lib/html-spa/rollup.config.js",
-            "test/**"
-        ]
-    },
-    "engines": {
-        "node": ">=8"
-    }
+  "name": "istanbul-reports",
+  "version": "3.0.0-alpha.3",
+  "description": "istanbul reports",
+  "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "scripts": {
+    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha --recursive",
+    "prepare": "webpack --config lib/html-spa/webpack.config.js --mode production",
+    "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
+  },
+  "dependencies": {
+    "handlebars": "^4.5.2",
+    "istanbul-lib-report": "^3.0.0-alpha.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.6.2",
+    "@babel/preset-env": "^7.6.2",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "chai": "^4.2.0",
+    "is-windows": "^1.0.2",
+    "istanbul-lib-coverage": "^3.0.0-alpha.1",
+    "mocha": "^6.2.1",
+    "nyc": "^14.1.1",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2",
+    "webpack": "^4.41.0",
+    "webpack-cli": "^3.3.9"
+  },
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git",
+    "directory": "packages/istanbul-reports"
+  },
+  "keywords": [
+    "istanbul",
+    "reports"
+  ],
+  "bugs": {
+    "url": "https://github.com/istanbuljs/istanbuljs/issues"
+  },
+  "homepage": "https://istanbul.js.org/",
+  "nyc": {
+    "exclude": [
+      "lib/html/assets/**",
+      "lib/html-spa/assets/**",
+      "lib/html-spa/rollup.config.js",
+      "test/**"
+    ]
+  },
+  "engines": {
+    "node": ">=8"
+  }
 }

--- a/packages/istanbul-reports/package.json
+++ b/packages/istanbul-reports/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "istanbul-reports",
-  "version": "3.0.0-alpha.3",
-  "description": "istanbul reports",
-  "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
-  "main": "index.js",
-  "files": [
-    "index.js",
-    "lib"
-  ],
-  "scripts": {
-    "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha --recursive",
-    "prepare": "webpack --config lib/html-spa/webpack.config.js --mode production",
-    "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
-  },
-  "dependencies": {
-    "handlebars": "^4.4.2",
-    "istanbul-lib-report": "^3.0.0-alpha.1"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.6.2",
-    "@babel/preset-env": "^7.6.2",
-    "@babel/preset-react": "^7.0.0",
-    "babel-loader": "^8.0.6",
-    "chai": "^4.2.0",
-    "is-windows": "^1.0.2",
-    "istanbul-lib-coverage": "^3.0.0-alpha.1",
-    "mocha": "^6.2.1",
-    "nyc": "^14.1.1",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2",
-    "webpack": "^4.41.0",
-    "webpack-cli": "^3.3.9"
-  },
-  "license": "BSD-3-Clause",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git",
-    "directory": "packages/istanbul-reports"
-  },
-  "keywords": [
-    "istanbul",
-    "reports"
-  ],
-  "bugs": {
-    "url": "https://github.com/istanbuljs/istanbuljs/issues"
-  },
-  "homepage": "https://istanbul.js.org/",
-  "nyc": {
-    "exclude": [
-      "lib/html/assets/**",
-      "lib/html-spa/assets/**",
-      "lib/html-spa/rollup.config.js",
-      "test/**"
-    ]
-  },
-  "engines": {
-    "node": ">=8"
-  }
+    "name": "istanbul-reports",
+    "version": "3.0.0-alpha.3",
+    "description": "istanbul reports",
+    "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
+    "main": "index.js",
+    "files": [
+        "index.js",
+        "lib"
+    ],
+    "scripts": {
+        "test": "nyc --nycrc-path=../../monorepo-per-package-nycrc.json mocha --recursive",
+        "prepare": "webpack --config lib/html-spa/webpack.config.js --mode production",
+        "prepare:watch": "webpack --config lib/html-spa/webpack.config.js --watch --mode development"
+    },
+    "dependencies": {
+        "handlebars": "^4.5.2",
+        "istanbul-lib-report": "^3.0.0-alpha.1"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.6.2",
+        "@babel/preset-env": "^7.6.2",
+        "@babel/preset-react": "^7.0.0",
+        "babel-loader": "^8.0.6",
+        "chai": "^4.2.0",
+        "is-windows": "^1.0.2",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "mocha": "^6.2.1",
+        "nyc": "^14.1.1",
+        "react": "^16.10.2",
+        "react-dom": "^16.10.2",
+        "webpack": "^4.41.0",
+        "webpack-cli": "^3.3.9"
+    },
+    "license": "BSD-3-Clause",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/istanbuljs/istanbuljs.git",
+        "directory": "packages/istanbul-reports"
+    },
+    "keywords": [
+        "istanbul",
+        "reports"
+    ],
+    "bugs": {
+        "url": "https://github.com/istanbuljs/istanbuljs/issues"
+    },
+    "homepage": "https://istanbul.js.org/",
+    "nyc": {
+        "exclude": [
+            "lib/html/assets/**",
+            "lib/html-spa/assets/**",
+            "lib/html-spa/rollup.config.js",
+            "test/**"
+        ]
+    },
+    "engines": {
+        "node": ">=8"
+    }
 }


### PR DESCRIPTION
Update Handlebars dependency to fix the arbitrary code execution.

> Versions of handlebars prior to 4.5.2 are vulnerable to Arbitrary Code Execution The package's lookup helper fails to properly validate templates, allowing attackers to submit templates that execute arbitrary JavaScript in the system. It can be used to run arbitrary code in a server processing Handlebars templates or on a victim's browser (effectively serving as Cross-Site Scripting).
([https://www.npmjs.com/advisories/1316](https://www.npmjs.com/advisories/1316))