### PR TITLE
fix: Update to support nyc 15.

### DIFF
--- a/packages/nyc-config-typescript/index.js
+++ b/packages/nyc-config-typescript/index.js
@@ -1,16 +1,8 @@
 'use strict';
 
+const { parserPlugins } = require('@istanbuljs/schema').defaults.nyc;
+
 module.exports = {
     cache: false,
-    extension: ['.ts', '.tsx'],
-    exclude: [
-        '**/*.d.ts',
-        'coverage/**',
-        'packages/*/test/**',
-        'test/**',
-        'test{,-*}.ts',
-        '**/*{.,-}{test,spec}.ts',
-        '**/__tests__/**',
-        '**/node_modules/**'
-    ]
+    parserPlugins: parserPlugins.concat('typescript')
 };

--- a/packages/nyc-config-typescript/package.json
+++ b/packages/nyc-config-typescript/package.json
@@ -33,7 +33,11 @@
   "engines": {
     "node": ">=8"
   },
+  "dependencies": {
+    "@istanbuljs/schema": "^0.1.2"
+  },
   "peerDependencies": {
+    "nyc": ">=15",
     "source-map-support": "*",
     "ts-node": "*"
   }


### PR DESCRIPTION
BREAKING CHANGE: This configuration is no longer valid for nyc 14 and
below.

---

@JaKXz do you agree that this is a breaking change?  Sorry I didn't catch this before releasing 1.0.0.