### PR TITLE
fix: Always call coverage initialization function

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -28,7 +28,6 @@ class VisitState {
         ignoreClassMethods = []
     ) {
         this.varName = genVar(sourceFilePath);
-        this.varCalled = false;
         this.attrs = {};
         this.nextIgnore = null;
         this.cov = new SourceCoverage(sourceFilePath);
@@ -168,7 +167,6 @@ class VisitState {
                 ? // If `index` present, turn `x` into `x[index]`.
                   x => T.memberExpression(x, T.numericLiteral(index), true)
                 : x => x;
-        this.varCalled = true;
         return T.updateExpression(
             '++',
             wrap(
@@ -664,14 +662,12 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {}) {
                 INITIAL: coverageNode,
                 HASH: T.stringLiteral(hash)
             });
-            // explicitly call this.varName if this file has no coverage
-            if (!visitState.varCalled) {
-                path.node.body.unshift(
-                    T.expressionStatement(
-                        T.callExpression(T.identifier(visitState.varName), [])
-                    )
-                );
-            }
+            // explicitly call this.varName to ensure coverage is always initialized
+            path.node.body.unshift(
+                T.expressionStatement(
+                    T.callExpression(T.identifier(visitState.varName), [])
+                )
+            );
             path.node.body.unshift(cv);
             return {
                 fileCoverage: coverageData,

--- a/packages/istanbul-lib-instrument/test/varia.test.js
+++ b/packages/istanbul-lib-instrument/test/varia.test.js
@@ -96,7 +96,7 @@ describe('varia', () => {
         const code = v.getGeneratedCode();
         assert.ok(
             code.match(
-                /return actualCoverage;}export function fn1\(\){cov_(.+)\.f\[\d+\]\+\+;}export default function\(\){cov_(.+)\.f\[\d+\]\+\+;}/
+                /return actualCoverage;}cov_([^(]+)\(\);export function fn1\(\){cov_(.+)\.f\[\d+\]\+\+;}export default function\(\){cov_(.+)\.f\[\d+\]\+\+;}/
             )
         );
     });


### PR DESCRIPTION
Ensure that sources initialize coverage data even if no code is run.

---

The primary use case for this is ES modules that are not transpiled to CJS.  For example create fn1.js:

```js
export function fn1() {
  console.log('test');
}
```

And index.js:
```js
import {fn1} from './fn1.js';

if (false) {
  fn1();
}
```

The expected result is for `fn1.js` to be reported as zero coverage but since the file has code but does not execute any top-level code it never gets in this test case.