### PR TITLE
fix wrong computed name in cobertura when using v8 coverage

### DIFF
--- a/packages/istanbul-reports/lib/cobertura/index.js
+++ b/packages/istanbul-reports/lib/cobertura/index.js
@@ -91,7 +91,7 @@ class CoberturaReport extends ReportBase {
         Object.entries(fnMap).forEach(([k, { name, decl }]) => {
             const hits = fileCoverage.f[k];
             this.xml.openTag('method', {
-                name,
+                name: asMethodName(name),
                 hits,
                 signature: '()V' //fake out a no-args void return
             });
@@ -144,6 +144,11 @@ function asJavaPackage(node) {
 
 function asClassName(node) {
     return node.getRelativeName().replace(/.*[\\/]/, '');
+}
+
+function asMethodName(name) {
+    // avoid invalid xml structure in method name like <method name="map.<computed>.f" hits="1" signature="()V">
+    return name.replace('<', '&lt;').replace('>', '&gt;');
 }
 
 module.exports = CoberturaReport;


### PR DESCRIPTION
This PR fixes https://github.com/istanbuljs/istanbuljs/issues/527 -  when using v8 coverage, you sometimes get `<computed>` in message name, and cobertura can't process generated file with message like this:

```
11:09:42  FATAL: Unable to parse builds/8/coverage.xml
11:09:42  hudson.util.IOException2: Cannot parse coverage results
11:09:42  	at hudson.plugins.cobertura.CoberturaCoverageParser.parse(CoberturaCoverageParser.java:84)
11:09:42  	at hudson.plugins.cobertura.CoberturaCoverageParser.parse(CoberturaCoverageParser.java:52)
11:09:42  	at hudson.plugins.cobertura.CoberturaPublisher.perform(CoberturaPublisher.java:594)
11:09:42  	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
11:09:42  	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
11:09:42  	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
11:09:42  	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
11:09:42  	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
11:09:42  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
11:09:42  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
11:09:42  	at java.lang.Thread.run(Thread.java:748)
11:09:42  Caused by: org.xml.sax.SAXParseException; lineNumber: 7441; columnNumber: 31; The value of attribute "name" associated with an element type "method" must not contain the '<' character.
```