### PR TITLE
fix: cobertura should escape invalid characters

### DIFF
--- a/packages/istanbul-reports/lib/cobertura/index.js
+++ b/packages/istanbul-reports/lib/cobertura/index.js
@@ -4,6 +4,7 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 const path = require('path');
+const { escape } = require('html-escaper');
 const { ReportBase } = require('istanbul-lib-report');
 
 class CoberturaReport extends ReportBase {
@@ -59,7 +60,7 @@ class CoberturaReport extends ReportBase {
             return;
         }
         this.xml.openTag('package', {
-            name: asJavaPackage(node),
+            name: escape(asJavaPackage(node)),
             'line-rate': metrics.lines.pct / 100.0,
             'branch-rate': metrics.branches.pct / 100.0
         });
@@ -80,7 +81,7 @@ class CoberturaReport extends ReportBase {
         const branchByLine = fileCoverage.getBranchCoverageByLine();
 
         this.xml.openTag('class', {
-            name: asClassName(node),
+            name: escape(asClassName(node)),
             filename: path.relative(this.projectRoot, fileCoverage.path),
             'line-rate': metrics.lines.pct / 100.0,
             'branch-rate': metrics.branches.pct / 100.0
@@ -91,7 +92,7 @@ class CoberturaReport extends ReportBase {
         Object.entries(fnMap).forEach(([k, { name, decl }]) => {
             const hits = fileCoverage.f[k];
             this.xml.openTag('method', {
-                name,
+                name: escape(name),
                 hits,
                 signature: '()V' //fake out a no-args void return
             });


### PR DESCRIPTION
see: https://github.com/bcoe/c8/issues/149

Fixes #527
Closes #528