### PR TITLE
fix: Add ts-ignore to reassignment of generated function

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -534,7 +534,8 @@ const globalTemplateVariable = template(`
         var global = GLOBAL_COVERAGE_SCOPE;
 `);
 // the template to insert at the top of the program.
-const coverageTemplate = template(`
+const coverageTemplate = template(
+    `
     function COVERAGE_FUNCTION () {
         var path = PATH;
         var hash = HASH;
@@ -556,7 +557,9 @@ const coverageTemplate = template(`
 
         return actualCoverage;
     }
-`, {preserveComments: true});
+`,
+    { preserveComments: true }
+);
 // the rewire plugin (and potentially other babel middleware)
 // may cause files to be instrumented twice, see:
 // https://github.com/istanbuljs/babel-plugin-istanbul/issues/94

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -547,13 +547,16 @@ const coverageTemplate = template(`
         }
 
         var actualCoverage = coverage[path];
-        COVERAGE_FUNCTION = function () {
-          return actualCoverage;
+        {
+            // @ts-ignore
+            COVERAGE_FUNCTION = function () {
+                return actualCoverage;
+            }
         }
 
         return actualCoverage;
     }
-`);
+`, {preserveComments: true});
 // the rewire plugin (and potentially other babel middleware)
 // may cause files to be instrumented twice, see:
 // https://github.com/istanbuljs/babel-plugin-istanbul/issues/94


### PR DESCRIPTION
Fixes istanbuljs/nyc#1292