### PR TITLE
Support projectRoot in json and json-summary reporters

### DIFF
--- a/packages/istanbul-reports/lib/json-summary/index.js
+++ b/packages/istanbul-reports/lib/json-summary/index.js
@@ -3,6 +3,7 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const path = require('path');
 const { ReportBase } = require('istanbul-lib-report');
 
 class JsonSummaryReport extends ReportBase {
@@ -12,6 +13,7 @@ class JsonSummaryReport extends ReportBase {
         this.file = opts.file || 'coverage-summary.json';
         this.contentWriter = null;
         this.first = true;
+        this.projectRoot = opts.projectRoot;
     }
 
     onStart(root, context) {
@@ -26,7 +28,13 @@ class JsonSummaryReport extends ReportBase {
         } else {
             cw.write(',');
         }
-        cw.write(JSON.stringify(filePath));
+        cw.write(
+            JSON.stringify(
+                this.projectRoot != null
+                    ? path.relative(this.projectRoot, filePath)
+                    : filePath
+            )
+        );
         cw.write(': ');
         cw.write(JSON.stringify(sc));
         cw.println('');

--- a/packages/istanbul-reports/lib/json/index.js
+++ b/packages/istanbul-reports/lib/json/index.js
@@ -3,6 +3,7 @@
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+const path = require('path');
 const { ReportBase } = require('istanbul-lib-report');
 
 class JsonReport extends ReportBase {
@@ -11,6 +12,7 @@ class JsonReport extends ReportBase {
 
         this.file = opts.file || 'coverage-final.json';
         this.first = true;
+        this.projectRoot = opts.projectRoot;
     }
 
     onStart(root, context) {
@@ -19,7 +21,10 @@ class JsonReport extends ReportBase {
     }
 
     onDetail(node) {
-        const fc = node.getFileCoverage();
+        let fc = node.getFileCoverage();
+        if (this.projectRoot != null) {
+            fc = { ...fc, path: path.relative(this.projectRoot, fc.path) };
+        }
         const key = fc.path;
         const cw = this.contentWriter;
 

--- a/packages/istanbul-reports/lib/json/index.js
+++ b/packages/istanbul-reports/lib/json/index.js
@@ -23,7 +23,12 @@ class JsonReport extends ReportBase {
     onDetail(node) {
         let fc = node.getFileCoverage();
         if (this.projectRoot != null) {
-            fc = { ...fc, path: path.relative(this.projectRoot, fc.path) };
+            const relativePath = path.relative(this.projectRoot, fc.path);
+            fc = {
+                ...fc,
+                path: relativePath,
+                data: { ...fc.data, path: relativePath }
+            };
         }
         const key = fc.path;
         const cw = this.contentWriter;


### PR DESCRIPTION
Sometimes it's more convenient to have relative paths in JSON reports