### PR TITLE
fix: Prevent readInitialCoverage from reading babel config

### DIFF
--- a/packages/istanbul-lib-instrument/src/read-coverage.js
+++ b/packages/istanbul-lib-instrument/src/read-coverage.js
@@ -14,6 +14,8 @@ function getAst(code) {
 
     // Parse as leniently as possible
     return parseSync(code, {
+        babelrc: false,
+        configFile: false,
         parserOpts: {
             allowImportExportEverywhere: true,
             allowReturnOutsideFunction: true,


### PR DESCRIPTION
CC @SimenB