### PR TITLE
lcovonly - onDetail - allow `meta` to be undefined

### DIFF
--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -50,6 +50,9 @@ class LcovOnlyReport extends ReportBase {
 
         Object.entries(branches).forEach(([key, branchArray]) => {
             const meta = branchMap[key];
+            if (!meta) {
+                return;
+            }
             const { line } = meta.loc.start;
             branchArray.forEach((b, i) => {
                 writer.println('BRDA:' + [line, key, i, b].join(','));


### PR DESCRIPTION
I'm not 100% on this as I'm not familiar with istanbul's inner workings, but this seems like a sensible check.

Fixes #572