### PR TITLE
fix: ensure inputSourceMap is a plain object before instrumenting

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -632,6 +632,13 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {}) {
                     sourceMappingURL: visitState.sourceMappingURL
                 };
             }
+            const { inputSourceMap } = coverageData;
+            // ensure inputSourceMap is a plain object
+            if (inputSourceMap) {
+                coverageData.inputSourceMap = JSON.parse(
+                    JSON.stringify(inputSourceMap)
+                );
+            }
             coverageData[MAGIC_KEY] = MAGIC_VALUE;
             const hash = createHash(SHA)
                 .update(JSON.stringify(coverageData))
@@ -640,6 +647,10 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {}) {
             const coverageNode = T.valueToNode(coverageData);
             delete coverageData[MAGIC_KEY];
             delete coverageData.hash;
+            // restore `inputSourceMap`
+            if (inputSourceMap) {
+                coverageData.inputSourceMap = inputSourceMap;
+            }
             let gvTemplate;
             if (opts.coverageGlobalScopeFunc) {
                 if (path.scope.getBinding('Function')) {


### PR DESCRIPTION
This PR fixes a regression introduced in #484. When `lib-instrument` converts `coverageData` to AST nodes, babel will [throw](https://github.com/babel/babel/blob/eea156b2cb8deecfcf82d52aa1b71ba4995c7d68/packages/babel-types/src/converters/valueToNode.js#L92) on the `inputSourceMap` because Babel don't know how to represent this object as literals since `inputSourceMap` is an instance of `SourceMapGenerator`.

In this PR I ensure `inputSourceMap` is a plain object and restore it after `coverageData` has been converted to AST. I am not familiar with the whole picture so please correct me if I overlooked any mistakes.

Context: 
https://github.com/babel/babel/issues/11614
https://github.com/facebook/jest/issues/10089