### PR TITLE
Add 'ignoreGuardStatements' option

### DIFF
--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -20,6 +20,7 @@ import readInitialCoverage from './read-coverage';
  * @param {boolean} [opts.autoWrap=false] set to true to allow `return` statements outside of functions.
  * @param {boolean} [opts.produceSourceMap=false] set to true to produce a source map for the instrumented code.
  * @param {Array} [opts.ignoreClassMethods=[]] set to array of class method names to ignore for coverage.
+ * @param {Array} [opts.ignoreGuardStatements=[]] ignore all guard statements. Can contain any of 'returns', 'literalReturns', 'identifierReturns', 'voidReturns', 'throws', 'continues', 'breaks'
  * @param {Function} [opts.sourceMapUrlCallback=null] a callback function that is called when a source map URL
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on
@@ -77,6 +78,7 @@ class Instrumenter {
                             coverageGlobalScopeFunc:
                                 opts.coverageGlobalScopeFunc,
                             ignoreClassMethods: opts.ignoreClassMethods,
+                            ignoreGuardStatements: opts.ignoreGuardStatements,
                             inputSourceMap
                         });
 

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -25,7 +25,8 @@ class VisitState {
         types,
         sourceFilePath,
         inputSourceMap,
-        ignoreClassMethods = []
+        ignoreClassMethods = [],
+        ignoreGuardStatements = []
     ) {
         this.varName = genVar(sourceFilePath);
         this.attrs = {};
@@ -36,6 +37,7 @@ class VisitState {
             this.cov.inputSourceMap(inputSourceMap);
         }
         this.ignoreClassMethods = ignoreClassMethods;
+        this.ignoreGuardStatements = ignoreGuardStatements;
         this.types = types;
         this.sourceMappingURL = null;
     }
@@ -409,11 +411,62 @@ function convertArrowExpression(path) {
     }
 }
 
+function isIgnoredGuard(n) {
+    if (!this.ignoreGuardStatements
+        || n.type !== 'BlockStatement'
+        || !Array.isArray(this.ignoreGuardStatements)
+        || !this.ignoreGuardStatements.length) {
+        return false;
+    }
+    if (n.body.length !== 1) {
+        // only ignore simple bodies (signle statement)
+        return false;
+    }
+    const stm = n.body[0];
+    if (stm.type === 'ThrowStatement') {
+        // ignore throws
+        return this.ignoreGuardStatements.includes('throws');
+    }
+    if (stm.type === 'ContinueStatement') {
+        // ignore continues
+        return this.ignoreGuardStatements.includes('continues');
+    }
+    if (stm.type === 'BreakStatement') {
+        // ignore continues
+        return this.ignoreGuardStatements.includes('breaks');
+    }
+    if (stm.type === 'ReturnStatement') {
+        if (!this.ignoreGuardStatements) {
+            return false;
+        }
+        if (this.ignoreGuardStatements.includes('returns')) {
+            // ignore all returns
+            return true;
+        }
+        if (!stm.argument) {
+            return this.ignoreGuardStatements.includes('literalReturns')
+                || this.ignoreGuardStatements.includes('voidReturns');
+        }
+        switch (stm.argument.type) {
+            case 'NumericLiteral':
+            case 'BooleanLiteral':
+            case 'StringLiteral':
+            case 'NullLiteral':
+                return this.ignoreGuardStatements.includes('literalReturns');
+            case 'Identifier':
+                return stm.argument.name === 'undefined' && this.ignoreGuardStatements.includes('literalReturns')
+                    || this.ignoreGuardStatements.includes('identifierReturns');
+
+        }
+    }
+    return false;
+}
+
 function coverIfBranches(path) {
     const n = path.node;
     const hint = this.hintFor(n);
-    const ignoreIf = hint === 'if';
-    const ignoreElse = hint === 'else';
+    const ignoreIf = hint === 'if' || isIgnoredGuard.call(this, n.consequent);
+    const ignoreElse = hint === 'else' || isIgnoredGuard.call(this, n.alternate);
     const branch = this.cov.newBranch('if', n.loc);
 
     if (ignoreIf) {
@@ -595,6 +648,7 @@ function shouldIgnoreFile(programNode) {
  * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
  * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
  * @param {Array} [opts.ignoreClassMethods=[]] names of methods to ignore by default on classes.
+ * @param {Array} [opts.ignoreGuardStatements=[]] ignore all guard statements. Can contain any of 'returns', 'literalReturns', 'identifierReturns', 'voidReturns', 'throws', 'continues', 'breaks'
  * @param {object} [opts.inputSourceMap=undefined] the input source map, that maps the uninstrumented code back to the
  * original code.
  */
@@ -608,7 +662,8 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {}) {
         types,
         sourceFilePath,
         opts.inputSourceMap,
-        opts.ignoreClassMethods
+        opts.ignoreClassMethods,
+        opts.ignoreGuardStatements
     );
     return {
         enter(path) {

--- a/packages/istanbul-lib-instrument/test/already-instrumented.test.js
+++ b/packages/istanbul-lib-instrument/test/already-instrumented.test.js
@@ -17,9 +17,8 @@ function instrument(code, inputSourceMap) {
     };
 }
 
-const instrumented = instrument(`console.log('basic test');`);
-
 it('should not alter already instrumented code', () => {
+    const instrumented = instrument(`console.log('basic test');`);
     const result = instrument(instrumented.code, instrumented.sourceMap);
     [instrumented, result].forEach(({ sourceMap }) => {
         // XXX Ignore source-map difference caused by:

--- a/packages/istanbul-lib-instrument/test/specs/ignored-guards.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/ignored-guards.yaml
@@ -1,0 +1,229 @@
+---
+name: ignores throw
+code: |
+  output = -1;
+  if (args[0] > args [1]) throw new Error('Error !')
+instrumentOpts:
+  ignoreGuardStatements: ["throws"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: does not ignores throw
+code: |
+  output = -1;
+  if (args[0] > args [1]) throw new Error('Error !')
+instrumentOpts:
+  ignoreGuardStatements: ["returns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [0, 1] }
+    statements: { "0": 1, "1": 1, "2": 0 }
+
+---
+name: ignores void return
+code: |
+  output = -1;
+  if (args[0] > args [1]) return
+instrumentOpts:
+  ignoreGuardStatements: ["voidReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores continue
+code: |
+  output = 3;
+  while (--output>0) {
+    if (args[0] > args [1]) continue
+  }
+instrumentOpts:
+  ignoreGuardStatements: ["continues"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: 0
+    lines: { "1": 1, "2": 1, "3": 2 }
+    branches: { "0": [2] }
+    statements: { "0": 1, "1": 1, "2": 2 }
+
+---
+name: ignores break
+code: |
+  output = 3;
+  while (--output>0) {
+    if (args[0] > args [1]) break
+  }
+instrumentOpts:
+  ignoreGuardStatements: ["breaks"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: 0
+    lines: { "1": 1, "2": 1, "3": 2 }
+    branches: { "0": [2] }
+    statements: { "0": 1, "1": 1, "2": 2 }
+
+
+---
+name: ignores numeric literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return 0
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: does not ignore numeric literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return 0
+instrumentOpts:
+  ignoreGuardStatements: ["voidReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [0, 1] }
+    statements: { "0": 1, "1": 1, "2": 0 }
+
+---
+name: ignores bool literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return false
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores string literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return 'nope'
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores null literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return null
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores undefined literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return undefined
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores identifier literal returns
+code: |
+  output = -1;
+  if (args[0] > args [1]) return output
+instrumentOpts:
+  ignoreGuardStatements: ["identifierReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: ignores complex return
+code: |
+  output = -1;
+  if (args[0] > args [1]) return args[0]
+instrumentOpts:
+  ignoreGuardStatements: ["returns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [1] }
+    statements: { "0": 1, "1": 1 }
+
+---
+name: does not ignore complex return
+code: |
+  output = -1;
+  if (args[0] > args [1]) return args[0]
+instrumentOpts:
+  ignoreGuardStatements: ["literalReturns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [0, 1] }
+    statements: { "0": 1, "1": 1, "2": 0 }
+
+---
+name: simple if single line does not ignore statement
+code: |
+  output = -1;
+  if (args[0] > args [1])  output = args[0];
+instrumentOpts:
+  ignoreGuardStatements: ["returns"]
+tests:
+  - name: default test
+    args: [10, 20]
+    out: -1
+    lines: { "1": 1, "2": 1 }
+    branches: { "0": [0, 1] }
+    statements: { "0": 1, "1": 1, "2": 0 }


### PR DESCRIPTION
### Motivation

One writes dummy statements like this on a daily basis:

```javascript
if (!myArgument) {
   throw new Error('my argument should not be null');
}
```

They are quite harmfull, often "useless" (just here to check something that is supposed to never happen), and are, most of the time, useless to check for coverage.

This pull requests allows to pass an option to istanbul instrumenter that systematically ignores such 'guard' statements, without having to clutter our code with thousands of `/* istanbul ignore if */`s

### Solution

What would you think of the `ignoreGuardStatements` that this pull request introduces ?

It works as follows:

```javascript
// When passing { ignoreGuardStatements: ['returns'] } 
if (condition) {
   return whatever; // will ignore any return statement
}

// When passing { ignoreGuardStatements: ['literalReturns'] }
if (condition) {
   return false; // will only ignore literal values (numbers, strings, null, undefined)
}

// When passing { ignoreGuardStatements: ['identifierReturns'] }
if (condition) {
   return myVariable; // will only ignore identifier return values
}

// When passing { ignoreGuardStatements: ['voidReturns'] }
if (condition) {
   return; // will only ignore void returns
}

// When passing { ignoreGuardStatements: ['voidReturns'] }
if (condition) {
   new whatever: // will ignore any throw statement
}

// When passing  { ignoreGuardStatements: ['continues'] }
while (condition1) {
  if (condition2) {
     continue; // will be ignored
  }
}

// When passing  { ignoreGuardStatements: ['breaks'] }
while (condition1) {
  if (condition2) {
     break; // will be ignored
  }
}
```

Of course, you can combine several of these options to ignore multiple guard patterns (that's why the array is for).
