### PR TITLE
Fixes #593, increase precision when calculating percentages

### DIFF
--- a/packages/istanbul-lib-coverage/lib/percent.js
+++ b/packages/istanbul-lib-coverage/lib/percent.js
@@ -7,7 +7,7 @@
 module.exports = function percent(covered, total) {
     let tmp;
     if (total > 0) {
-        tmp = (1000 * 100 * covered) / total + 5;
+        tmp = (1000 * 100 * covered) / total;
         return Math.floor(tmp / 10) / 100;
     } else {
         return 100.0;

--- a/packages/istanbul-lib-coverage/test/percent.test.js
+++ b/packages/istanbul-lib-coverage/test/percent.test.js
@@ -1,0 +1,18 @@
+'use strict';
+/* globals describe, it */
+
+const assert = require('chai').assert;
+const percent = require('../lib/percent');
+
+describe('percent calculation', () => {
+    it('calculates percentage covered and total', () => {
+        const p = percent(1, 1);
+
+        assert.equal(p, 100);
+    });
+    it('calculates percentage with enough precision to detect minor differences with large covered and total', () => {
+        const p = percent(999998, 999999);
+
+        assert.isBelow(p, 100);
+    });
+});

--- a/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
@@ -1,6 +1,6 @@
 {
     "title": "100% line coverage, missing branch coverage",
-    "textReportExpected": "----------|---------|----------|---------|---------|-------------------\nFile      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s \n----------|---------|----------|---------|---------|-------------------\n\u001b[32;1mAll files\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.35\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m                 \u001b[0m \n\u001b[32;1m index.js\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.35\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m21,29            \u001b[0m \n----------|---------|----------|---------|---------|-------------------\n",
+    "textReportExpected": "----------|---------|----------|---------|---------|-------------------\nFile      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s \n----------|---------|----------|---------|---------|-------------------\n\u001b[32;1mAll files\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m                 \u001b[0m \n\u001b[32;1m index.js\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m21,29            \u001b[0m \n----------|---------|----------|---------|---------|-------------------\n",
     "htmlSpaFiles": ["index.js.html", "index.html"],
     "htmlSpaCoverageData": {
         "file": "",
@@ -17,7 +17,7 @@
                 "total": 43,
                 "covered": 41,
                 "skipped": 0,
-                "pct": 95.35,
+                "pct": 95.34,
                 "classForPercent": "high"
             },
             "functions": {
@@ -51,7 +51,7 @@
                         "total": 43,
                         "covered": 41,
                         "skipped": 0,
-                        "pct": 95.35,
+                        "pct": 95.34,
                         "classForPercent": "high"
                     },
                     "functions": {

--- a/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
@@ -1,6 +1,6 @@
 {
     "title": "missing line and branch coverage",
-    "textReportExpected": "----------|---------|----------|---------|---------|-------------------\nFile      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s \n----------|---------|----------|---------|---------|-------------------\n\u001b[32;1mAll files\u001b[0m | \u001b[32;1m  98.04\u001b[0m | \u001b[32;1m   95.35\u001b[0m | \u001b[32;1m  88.89\u001b[0m | \u001b[32;1m  97.87\u001b[0m | \u001b[31;1m                 \u001b[0m \n\u001b[32;1m index.js\u001b[0m | \u001b[32;1m  98.04\u001b[0m | \u001b[32;1m   95.35\u001b[0m | \u001b[32;1m  88.89\u001b[0m | \u001b[32;1m  97.87\u001b[0m | \u001b[31;1m9                \u001b[0m \n----------|---------|----------|---------|---------|-------------------\n",
+    "textReportExpected": "----------|---------|----------|---------|---------|-------------------\nFile      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s \n----------|---------|----------|---------|---------|-------------------\n\u001b[32;1mAll files\u001b[0m | \u001b[32;1m  98.03\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m  88.88\u001b[0m | \u001b[32;1m  97.87\u001b[0m | \u001b[31;1m                 \u001b[0m \n\u001b[32;1m index.js\u001b[0m | \u001b[32;1m  98.03\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m  88.88\u001b[0m | \u001b[32;1m  97.87\u001b[0m | \u001b[31;1m9                \u001b[0m \n----------|---------|----------|---------|---------|-------------------\n",
     "htmlSpaFiles": ["index.js.html", "index.html"],
     "htmlSpaCoverageData": {
         "file": "",
@@ -10,21 +10,21 @@
                 "total": 51,
                 "covered": 50,
                 "skipped": 0,
-                "pct": 98.04,
+                "pct": 98.03,
                 "classForPercent": "high"
             },
             "branches": {
                 "total": 43,
                 "covered": 41,
                 "skipped": 0,
-                "pct": 95.35,
+                "pct": 95.34,
                 "classForPercent": "high"
             },
             "functions": {
                 "total": 9,
                 "covered": 8,
                 "skipped": 0,
-                "pct": 88.89,
+                "pct": 88.88,
                 "classForPercent": "high"
             },
             "lines": {
@@ -44,21 +44,21 @@
                         "total": 51,
                         "covered": 50,
                         "skipped": 0,
-                        "pct": 98.04,
+                        "pct": 98.03,
                         "classForPercent": "high"
                     },
                     "branches": {
                         "total": 43,
                         "covered": 41,
                         "skipped": 0,
-                        "pct": 95.35,
+                        "pct": 95.34,
                         "classForPercent": "high"
                     },
                     "functions": {
                         "total": 9,
                         "covered": 8,
                         "skipped": 0,
-                        "pct": 88.89,
+                        "pct": 88.88,
                         "classForPercent": "high"
                     },
                     "lines": {


### PR DESCRIPTION
Increase precision when calculating percentages to fix of by one errors when dealing with large numbers.