### PR TITLE
Remove duplicate code

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -242,12 +242,8 @@ class VisitState {
         // get location for declaration
         switch (n.type) {
             case 'FunctionDeclaration':
-                /* istanbul ignore else: paranoid check */
-                if (n.id) {
-                    dloc = n.id.loc;
-                }
-                break;
             case 'FunctionExpression':
+                /* istanbul ignore else: paranoid check */
                 if (n.id) {
                     dloc = n.id.loc;
                 }


### PR DESCRIPTION
The body of this case clause duplicates the body of this case clause.