### PR TITLE
Add "missed" column to html-spa report

### DIFF
--- a/packages/istanbul-reports/lib/html-spa/assets/spa.css
+++ b/packages/istanbul-reports/lib/html-spa/assets/spa.css
@@ -252,8 +252,8 @@ a:hover {
     color: #666;
 }
 
-.coverage-summary .headercell:nth-child(4n - 2),
-.coverage-summary td:nth-child(4n - 2) {
+.coverage-summary .headercell:nth-child(5n - 2),
+.coverage-summary td:nth-child(5n - 2) {
     border-left: 2px solid #fcfcfc;
     padding-left: 2em;
 }

--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -99,6 +99,7 @@ class HtmlSpaReport extends ReportBase {
             total: metric.total,
             covered: metric.covered,
             skipped: metric.skipped,
+            missed: metric.total - metric.covered,
             pct: isEmpty ? 0 : metric.pct,
             classForPercent: isEmpty
                 ? 'empty'

--- a/packages/istanbul-reports/lib/html-spa/src/summaryTableHeader.js
+++ b/packages/istanbul-reports/lib/html-spa/src/summaryTableHeader.js
@@ -65,6 +65,12 @@ function SubHeadings({ sortKeyPrefix, onSort, activeSort }) {
                 activeSort={activeSort}
             />
             <SummaryTableHeaderCell
+                name="Missed"
+                onSort={onSort}
+                sortKey={sortKeyPrefix + '.missed'}
+                activeSort={activeSort}
+            />
+            <SummaryTableHeaderCell
                 name="Total"
                 onSort={onSort}
                 sortKey={sortKeyPrefix + '.total'}

--- a/packages/istanbul-reports/lib/html-spa/src/summaryTableLine.js
+++ b/packages/istanbul-reports/lib/html-spa/src/summaryTableLine.js
@@ -1,7 +1,7 @@
 const React = require('react');
 
 function MetricCells({ metrics }) {
-    const { classForPercent, pct, covered, total } = metrics;
+    const { classForPercent, pct, covered, missed, total } = metrics;
 
     return (
         <>
@@ -15,6 +15,7 @@ function MetricCells({ metrics }) {
                 </div>
             </td>
             <td className={'abs ' + classForPercent}>{covered}</td>
+            <td className={'abs ' + classForPercent}>{missed}</td>
             <td className={'abs ' + classForPercent}>{total}</td>
         </>
     );

--- a/packages/istanbul-reports/test/fixtures/specs/100-line-100-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/100-line-100-branch.json
@@ -9,6 +9,7 @@
             "statements": {
                 "total": 50,
                 "covered": 50,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -16,6 +17,7 @@
             "branches": {
                 "total": 39,
                 "covered": 39,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -23,6 +25,7 @@
             "functions": {
                 "total": 8,
                 "covered": 8,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -30,6 +33,7 @@
             "lines": {
                 "total": 46,
                 "covered": 46,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -43,6 +47,7 @@
                     "statements": {
                         "total": 50,
                         "covered": 50,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"
@@ -50,6 +55,7 @@
                     "branches": {
                         "total": 39,
                         "covered": 39,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"
@@ -57,6 +63,7 @@
                     "functions": {
                         "total": 8,
                         "covered": 8,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"
@@ -65,6 +72,7 @@
                         "total": 46,
                         "covered": 46,
                         "skipped": 0,
+                        "missed": 0,
                         "pct": 100,
                         "classForPercent": "high"
                     }

--- a/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/100-line-missing-branch.json
@@ -9,6 +9,7 @@
             "statements": {
                 "total": 50,
                 "covered": 50,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -16,6 +17,7 @@
             "branches": {
                 "total": 43,
                 "covered": 41,
+                "missed": 2,
                 "skipped": 0,
                 "pct": 95.35,
                 "classForPercent": "high"
@@ -23,6 +25,7 @@
             "functions": {
                 "total": 8,
                 "covered": 8,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -30,6 +33,7 @@
             "lines": {
                 "total": 46,
                 "covered": 46,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 100,
                 "classForPercent": "high"
@@ -43,6 +47,7 @@
                     "statements": {
                         "total": 50,
                         "covered": 50,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"
@@ -50,6 +55,7 @@
                     "branches": {
                         "total": 43,
                         "covered": 41,
+                        "missed": 2,
                         "skipped": 0,
                         "pct": 95.35,
                         "classForPercent": "high"
@@ -57,6 +63,7 @@
                     "functions": {
                         "total": 8,
                         "covered": 8,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"
@@ -64,6 +71,7 @@
                     "lines": {
                         "total": 46,
                         "covered": 46,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 100,
                         "classForPercent": "high"

--- a/packages/istanbul-reports/test/fixtures/specs/coalescence.json
+++ b/packages/istanbul-reports/test/fixtures/specs/coalescence.json
@@ -12,6 +12,7 @@
             "statements": {
                 "total": 20,
                 "covered": 6,
+                "missed": 14,
                 "skipped": 0,
                 "pct": 30,
                 "classForPercent": "low"
@@ -19,6 +20,7 @@
             "branches": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -26,6 +28,7 @@
             "functions": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -33,6 +36,7 @@
             "lines": {
                 "total": 18,
                 "covered": 6,
+                "missed": 12,
                 "skipped": 0,
                 "pct": 33.33,
                 "classForPercent": "low"
@@ -46,6 +50,7 @@
                     "statements": {
                         "total": 20,
                         "covered": 6,
+                        "missed": 14,
                         "skipped": 0,
                         "pct": 30,
                         "classForPercent": "low"
@@ -53,6 +58,7 @@
                     "branches": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -60,6 +66,7 @@
                     "functions": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -67,6 +74,7 @@
                     "lines": {
                         "total": 18,
                         "covered": 6,
+                        "missed": 12,
                         "skipped": 0,
                         "pct": 33.33,
                         "classForPercent": "low"

--- a/packages/istanbul-reports/test/fixtures/specs/empty-file-skip-empty.json
+++ b/packages/istanbul-reports/test/fixtures/specs/empty-file-skip-empty.json
@@ -12,6 +12,7 @@
             "statements": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -19,6 +20,7 @@
             "branches": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -26,6 +28,7 @@
             "functions": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -33,6 +36,7 @@
             "lines": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -46,6 +50,7 @@
                     "statements": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -53,6 +58,7 @@
                     "branches": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -60,6 +66,7 @@
                     "functions": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -67,6 +74,7 @@
                     "lines": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"

--- a/packages/istanbul-reports/test/fixtures/specs/empty-file.json
+++ b/packages/istanbul-reports/test/fixtures/specs/empty-file.json
@@ -9,6 +9,7 @@
             "statements": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -16,6 +17,7 @@
             "branches": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -23,6 +25,7 @@
             "functions": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -30,6 +33,7 @@
             "lines": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -43,6 +47,7 @@
                     "statements": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -50,6 +55,7 @@
                     "branches": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -57,6 +63,7 @@
                     "functions": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -64,6 +71,7 @@
                     "lines": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"

--- a/packages/istanbul-reports/test/fixtures/specs/maxcols.json
+++ b/packages/istanbul-reports/test/fixtures/specs/maxcols.json
@@ -12,6 +12,7 @@
             "statements": {
                 "total": 20,
                 "covered": 8,
+                "missed": 12,
                 "skipped": 0,
                 "pct": 40,
                 "classForPercent": "low"
@@ -19,6 +20,7 @@
             "branches": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -26,6 +28,7 @@
             "functions": {
                 "total": 0,
                 "covered": 0,
+                "missed": 0,
                 "skipped": 0,
                 "pct": 0,
                 "classForPercent": "empty"
@@ -33,6 +36,7 @@
             "lines": {
                 "total": 20,
                 "covered": 8,
+                "missed": 12,
                 "skipped": 0,
                 "pct": 40,
                 "classForPercent": "low"
@@ -46,6 +50,7 @@
                     "statements": {
                         "total": 20,
                         "covered": 8,
+                        "missed": 12,
                         "skipped": 0,
                         "pct": 40,
                         "classForPercent": "low"
@@ -53,6 +58,7 @@
                     "branches": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -60,6 +66,7 @@
                     "functions": {
                         "total": 0,
                         "covered": 0,
+                        "missed": 0,
                         "skipped": 0,
                         "pct": 0,
                         "classForPercent": "empty"
@@ -67,6 +74,7 @@
                     "lines": {
                         "total": 20,
                         "covered": 8,
+                        "missed": 12,
                         "skipped": 0,
                         "pct": 40,
                         "classForPercent": "low"

--- a/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
+++ b/packages/istanbul-reports/test/fixtures/specs/missing-line-missing-branch.json
@@ -9,6 +9,7 @@
             "statements": {
                 "total": 51,
                 "covered": 50,
+                "missed": 1,
                 "skipped": 0,
                 "pct": 98.04,
                 "classForPercent": "high"
@@ -16,6 +17,7 @@
             "branches": {
                 "total": 43,
                 "covered": 41,
+                "missed": 2,
                 "skipped": 0,
                 "pct": 95.35,
                 "classForPercent": "high"
@@ -23,6 +25,7 @@
             "functions": {
                 "total": 9,
                 "covered": 8,
+                "missed": 1,
                 "skipped": 0,
                 "pct": 88.89,
                 "classForPercent": "high"
@@ -30,6 +33,7 @@
             "lines": {
                 "total": 47,
                 "covered": 46,
+                "missed": 1,
                 "skipped": 0,
                 "pct": 97.87,
                 "classForPercent": "high"
@@ -43,6 +47,7 @@
                     "statements": {
                         "total": 51,
                         "covered": 50,
+                        "missed": 1,
                         "skipped": 0,
                         "pct": 98.04,
                         "classForPercent": "high"
@@ -50,6 +55,7 @@
                     "branches": {
                         "total": 43,
                         "covered": 41,
+                        "missed": 2,
                         "skipped": 0,
                         "pct": 95.35,
                         "classForPercent": "high"
@@ -57,6 +63,7 @@
                     "functions": {
                         "total": 9,
                         "covered": 8,
+                        "missed": 1,
                         "skipped": 0,
                         "pct": 88.89,
                         "classForPercent": "high"
@@ -64,6 +71,7 @@
                     "lines": {
                         "total": 47,
                         "covered": 46,
+                        "missed": 1,
                         "skipped": 0,
                         "pct": 97.87,
                         "classForPercent": "high"

--- a/packages/istanbul-reports/test/html-spa/src/getChildData.js
+++ b/packages/istanbul-reports/test/html-spa/src/getChildData.js
@@ -7,6 +7,7 @@ const mediumMetrics = {
     statements: {
         total: 2100,
         covered: 1337,
+        missed: 2100 - 1337,
         skipped: 0,
         pct: 63.67,
         classForPercent: 'medium'
@@ -14,6 +15,7 @@ const mediumMetrics = {
     branches: {
         total: 983,
         covered: 606,
+        missed: 983 - 606,
         skipped: 0,
         pct: 61.65,
         classForPercent: 'medium'
@@ -21,6 +23,7 @@ const mediumMetrics = {
     functions: {
         total: 476,
         covered: 312,
+        missed: 476 - 312,
         skipped: 0,
         pct: 65.55,
         classForPercent: 'medium'
@@ -28,6 +31,7 @@ const mediumMetrics = {
     lines: {
         total: 2044,
         covered: 1313,
+        missed: 2044 - 1313,
         skipped: 0,
         pct: 64.24,
         classForPercent: 'medium'


### PR DESCRIPTION
Fixes #579 

Happy to change this to an option, but I do find it by far the most useful way to sort coverage data, since it tells you exactly where your biggest gaps are. As the issue mentions, this is the default sort order in some other coverage visualization tools.

![sort-by-missed](https://user-images.githubusercontent.com/98301/107665124-2431cf80-6c5b-11eb-8e0b-e1d57f4e3537.gif)
