### PR TITLE
feat: Honor summarizer for text report

### DIFF
--- a/packages/istanbul-reports/lib/text/index.js
+++ b/packages/istanbul-reports/lib/text/index.js
@@ -225,7 +225,7 @@ function tableRow(
 
 class TextReport extends ReportBase {
     constructor(opts) {
-        super();
+        super(opts);
 
         opts = opts || {};
         const { maxCols } = opts;


### PR DESCRIPTION
This allows API users to pass a `summarizer` option to the text report.