### PR TITLE
fix: not deterministic file coverage merge

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -151,11 +151,11 @@ class FileCoverage {
         return this.data;
     }
 
-    sumHits(map, key, value){
-        if (typeof(map[key])!=="number"){
+    sumHits(map, key, value) {
+        if (typeof map[key] !== "number" ) {
             map[key] = value;
-        }else{
-            map[key] +=value;
+        } else {
+            map[key] += value;
         }
     }
 

--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -152,7 +152,7 @@ class FileCoverage {
     }
 
     sumHits(map, key, value) {
-        if (typeof map[key] !== 'number' ) {
+        if (typeof map[key] !== 'number') {
             map[key] = value;
         } else {
             map[key] += value;

--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -152,7 +152,7 @@ class FileCoverage {
     }
 
     sumHits(map, key, value) {
-        if (typeof map[key] !== "number" ) {
+        if (typeof map[key] !== 'number' ) {
             map[key] = value;
         } else {
             map[key] += value;


### PR DESCRIPTION
This PR fixes istanbuljs/nyc#1388 issue.

In dependence on the merge order of coverage files the hits of one are not taken over into the result file. 