### PR TITLE
Allow users to create custom summarizers

### DIFF
--- a/packages/istanbul-lib-report/lib/context.js
+++ b/packages/istanbul-lib-report/lib/context.js
@@ -114,8 +114,12 @@ class Context {
         return new tree.Visitor(partialVisitor);
     }
 
-    getTree(name = 'defaultSummarizer') {
-        return this._summarizerFactory[name];
+    getTree(nameOrFunction = 'defaultSummarizer') {
+        if (typeof nameOrFunction === 'function') {
+            return this._summarizerFactory.callSummarizer(nameOrFunction);
+        } else {
+            return this._summarizerFactory[nameOrFunction];
+        }
     }
 }
 

--- a/packages/istanbul-lib-report/lib/report-base.js
+++ b/packages/istanbul-lib-report/lib/report-base.js
@@ -1,15 +1,12 @@
 'use strict';
 
-// TODO: switch to class private field when targetting node.js 12
-const _summarizer = Symbol('ReportBase.#summarizer');
-
 class ReportBase {
     constructor(opts = {}) {
-        this[_summarizer] = opts.summarizer;
+        this._summarizer = opts.summarizer;
     }
 
     execute(context) {
-        context.getTree(this[_summarizer]).visit(this, context);
+        context.getTree(this._summarizer).visit(this, context);
     }
 }
 

--- a/packages/istanbul-lib-report/lib/summarizer-core.js
+++ b/packages/istanbul-lib-report/lib/summarizer-core.js
@@ -8,10 +8,6 @@ const coverage = require('istanbul-lib-coverage');
 const Path = require('./path');
 const { BaseNode, BaseTree } = require('./tree');
 
-/**
- * A report node, representing the coverage for either an individual file
- * or a folder of files.
- */
 class ReportNode extends BaseNode {
     constructor(path, fileCoverage) {
         super();
@@ -109,9 +105,6 @@ class ReportNode extends BaseNode {
     }
 }
 
-/**
- * A report tree is a tree of report nodes, used by reporters to organize the coverage report.
- */
 class ReportTree extends BaseTree {
     constructor(root, childPrefix) {
         super(root);
@@ -139,9 +132,6 @@ class ReportTree extends BaseTree {
     }
 }
 
-/**
- * A collection of utility functions useful for creating a report tree.
- */
 const Util = {
     addAllPaths(topPaths, nodeMap, path, node) {
         const parent = Util.findOrCreateParent(
@@ -266,7 +256,6 @@ module.exports = {
     ReportNode,
     ReportTree,
     Util,
-    Path,
     getFlatTree,
     getPkgTree,
     getNestedTree

--- a/packages/istanbul-lib-report/lib/summarizer-factory.js
+++ b/packages/istanbul-lib-report/lib/summarizer-factory.js
@@ -10,7 +10,7 @@ const {
     getPkgTree,
     getNestedTree,
     Util
-} = require('./summarizer');
+} = require('./summarizer-core');
 
 class SummarizerFactory {
     constructor(coverageMap, defaultSummarizer = 'pkg') {

--- a/packages/istanbul-lib-report/lib/summarizer-factory.js
+++ b/packages/istanbul-lib-report/lib/summarizer-factory.js
@@ -4,200 +4,13 @@
  */
 'use strict';
 
-const coverage = require('istanbul-lib-coverage');
 const Path = require('./path');
-const { BaseNode, BaseTree } = require('./tree');
-
-class ReportNode extends BaseNode {
-    constructor(path, fileCoverage) {
-        super();
-
-        this.path = path;
-        this.parent = null;
-        this.fileCoverage = fileCoverage;
-        this.children = [];
-    }
-
-    static createRoot(children) {
-        const root = new ReportNode(new Path([]));
-
-        children.forEach(child => {
-            root.addChild(child);
-        });
-
-        return root;
-    }
-
-    addChild(child) {
-        child.parent = this;
-        this.children.push(child);
-    }
-
-    asRelative(p) {
-        if (p.substring(0, 1) === '/') {
-            return p.substring(1);
-        }
-        return p;
-    }
-
-    getQualifiedName() {
-        return this.asRelative(this.path.toString());
-    }
-
-    getRelativeName() {
-        const parent = this.getParent();
-        const myPath = this.path;
-        let relPath;
-        let i;
-        const parentPath = parent ? parent.path : new Path([]);
-        if (parentPath.ancestorOf(myPath)) {
-            relPath = new Path(myPath.elements());
-            for (i = 0; i < parentPath.length; i += 1) {
-                relPath.shift();
-            }
-            return this.asRelative(relPath.toString());
-        }
-        return this.asRelative(this.path.toString());
-    }
-
-    getParent() {
-        return this.parent;
-    }
-
-    getChildren() {
-        return this.children;
-    }
-
-    isSummary() {
-        return !this.fileCoverage;
-    }
-
-    getFileCoverage() {
-        return this.fileCoverage;
-    }
-
-    getCoverageSummary(filesOnly) {
-        const cacheProp = `c_${filesOnly ? 'files' : 'full'}`;
-        let summary;
-
-        if (Object.prototype.hasOwnProperty.call(this, cacheProp)) {
-            return this[cacheProp];
-        }
-
-        if (!this.isSummary()) {
-            summary = this.getFileCoverage().toSummary();
-        } else {
-            let count = 0;
-            summary = coverage.createCoverageSummary();
-            this.getChildren().forEach(child => {
-                if (filesOnly && child.isSummary()) {
-                    return;
-                }
-                count += 1;
-                summary.merge(child.getCoverageSummary(filesOnly));
-            });
-            if (count === 0 && filesOnly) {
-                summary = null;
-            }
-        }
-        this[cacheProp] = summary;
-        return summary;
-    }
-}
-
-class ReportTree extends BaseTree {
-    constructor(root, childPrefix) {
-        super(root);
-
-        const maybePrefix = node => {
-            if (childPrefix && !node.isRoot()) {
-                node.path.unshift(childPrefix);
-            }
-        };
-        this.visit({
-            onDetail: maybePrefix,
-            onSummary(node) {
-                maybePrefix(node);
-                node.children.sort((a, b) => {
-                    const astr = a.path.toString();
-                    const bstr = b.path.toString();
-                    return astr < bstr
-                        ? -1
-                        : astr > bstr
-                        ? 1
-                        : /* istanbul ignore next */ 0;
-                });
-            }
-        });
-    }
-}
-
-function findCommonParent(paths) {
-    return paths.reduce(
-        (common, path) => common.commonPrefixPath(path),
-        paths[0] || new Path([])
-    );
-}
-
-function findOrCreateParent(parentPath, nodeMap, created = () => {}) {
-    let parent = nodeMap[parentPath.toString()];
-
-    if (!parent) {
-        parent = new ReportNode(parentPath);
-        nodeMap[parentPath.toString()] = parent;
-        created(parentPath, parent);
-    }
-
-    return parent;
-}
-
-function toDirParents(list) {
-    const nodeMap = Object.create(null);
-    list.forEach(o => {
-        const parent = findOrCreateParent(o.path.parent(), nodeMap);
-        parent.addChild(new ReportNode(o.path, o.fileCoverage));
-    });
-
-    return Object.values(nodeMap);
-}
-
-function addAllPaths(topPaths, nodeMap, path, node) {
-    const parent = findOrCreateParent(
-        path.parent(),
-        nodeMap,
-        (parentPath, parent) => {
-            if (parentPath.hasParent()) {
-                addAllPaths(topPaths, nodeMap, parentPath, parent);
-            } else {
-                topPaths.push(parent);
-            }
-        }
-    );
-
-    parent.addChild(node);
-}
-
-function foldIntoOneDir(node, parent) {
-    const { children } = node;
-    if (children.length === 1 && !children[0].fileCoverage) {
-        children[0].parent = parent;
-        return foldIntoOneDir(children[0], parent);
-    }
-    node.children = children.map(child => foldIntoOneDir(child, node));
-    return node;
-}
-
-function pkgSummaryPrefix(dirParents, commonParent) {
-    if (!dirParents.some(dp => dp.path.length === 0)) {
-        return;
-    }
-
-    if (commonParent.length === 0) {
-        return 'root';
-    }
-
-    return commonParent.name();
-}
+const {
+    getFlatTree,
+    getPkgTree,
+    getNestedTree,
+    Util
+} = require('./summarizer');
 
 class SummarizerFactory {
     constructor(coverageMap, defaultSummarizer = 'pkg') {
@@ -208,7 +21,7 @@ class SummarizerFactory {
             path: new Path(filePath),
             fileCoverage: coverageMap.fileCoverageFor(filePath)
         }));
-        this._commonParent = findCommonParent(
+        this._commonParent = Util.findCommonParent(
             this._initialList.map(o => o.path.parent())
         );
         if (this._commonParent.length > 0) {
@@ -218,63 +31,33 @@ class SummarizerFactory {
         }
     }
 
+    callSummarizer(summarizerFunction) {
+        return summarizerFunction(this._initialList, this._commonParent);
+    }
+
     get defaultSummarizer() {
         return this[this._defaultSummarizer];
     }
 
     get flat() {
         if (!this._flat) {
-            this._flat = new ReportTree(
-                ReportNode.createRoot(
-                    this._initialList.map(
-                        node => new ReportNode(node.path, node.fileCoverage)
-                    )
-                )
-            );
+            this._flat = this.callSummarizer(getFlatTree);
         }
 
         return this._flat;
     }
 
-    _createPkg() {
-        const dirParents = toDirParents(this._initialList);
-        if (dirParents.length === 1) {
-            return new ReportTree(dirParents[0]);
-        }
-
-        return new ReportTree(
-            ReportNode.createRoot(dirParents),
-            pkgSummaryPrefix(dirParents, this._commonParent)
-        );
-    }
-
     get pkg() {
         if (!this._pkg) {
-            this._pkg = this._createPkg();
+            this._pkg = this.callSummarizer(getPkgTree);
         }
 
         return this._pkg;
     }
 
-    _createNested() {
-        const nodeMap = Object.create(null);
-        const topPaths = [];
-        this._initialList.forEach(o => {
-            const node = new ReportNode(o.path, o.fileCoverage);
-            addAllPaths(topPaths, nodeMap, o.path, node);
-        });
-
-        const topNodes = topPaths.map(node => foldIntoOneDir(node));
-        if (topNodes.length === 1) {
-            return new ReportTree(topNodes[0]);
-        }
-
-        return new ReportTree(ReportNode.createRoot(topNodes));
-    }
-
     get nested() {
         if (!this._nested) {
-            this._nested = this._createNested();
+            this._nested = this.callSummarizer(getNestedTree);
         }
 
         return this._nested;

--- a/packages/istanbul-lib-report/lib/summarizer.js
+++ b/packages/istanbul-lib-report/lib/summarizer.js
@@ -1,0 +1,273 @@
+/*
+ Copyright 2012-2015, Yahoo Inc.
+ Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+const coverage = require('istanbul-lib-coverage');
+const Path = require('./path');
+const { BaseNode, BaseTree } = require('./tree');
+
+/**
+ * A report node, representing the coverage for either an individual file
+ * or a folder of files.
+ */
+class ReportNode extends BaseNode {
+    constructor(path, fileCoverage) {
+        super();
+
+        this.path = path;
+        this.parent = null;
+        this.fileCoverage = fileCoverage;
+        this.children = [];
+    }
+
+    static createRoot(children) {
+        const root = new ReportNode(new Path([]));
+
+        children.forEach(child => {
+            root.addChild(child);
+        });
+
+        return root;
+    }
+
+    addChild(child) {
+        child.parent = this;
+        this.children.push(child);
+    }
+
+    asRelative(p) {
+        if (p.substring(0, 1) === '/') {
+            return p.substring(1);
+        }
+        return p;
+    }
+
+    getQualifiedName() {
+        return this.asRelative(this.path.toString());
+    }
+
+    getRelativeName() {
+        const parent = this.getParent();
+        const myPath = this.path;
+        let relPath;
+        let i;
+        const parentPath = parent ? parent.path : new Path([]);
+        if (parentPath.ancestorOf(myPath)) {
+            relPath = new Path(myPath.elements());
+            for (i = 0; i < parentPath.length; i += 1) {
+                relPath.shift();
+            }
+            return this.asRelative(relPath.toString());
+        }
+        return this.asRelative(this.path.toString());
+    }
+
+    getParent() {
+        return this.parent;
+    }
+
+    getChildren() {
+        return this.children;
+    }
+
+    isSummary() {
+        return !this.fileCoverage;
+    }
+
+    getFileCoverage() {
+        return this.fileCoverage;
+    }
+
+    getCoverageSummary(filesOnly) {
+        const cacheProp = `c_${filesOnly ? 'files' : 'full'}`;
+        let summary;
+
+        if (Object.prototype.hasOwnProperty.call(this, cacheProp)) {
+            return this[cacheProp];
+        }
+
+        if (!this.isSummary()) {
+            summary = this.getFileCoverage().toSummary();
+        } else {
+            let count = 0;
+            summary = coverage.createCoverageSummary();
+            this.getChildren().forEach(child => {
+                if (filesOnly && child.isSummary()) {
+                    return;
+                }
+                count += 1;
+                summary.merge(child.getCoverageSummary(filesOnly));
+            });
+            if (count === 0 && filesOnly) {
+                summary = null;
+            }
+        }
+        this[cacheProp] = summary;
+        return summary;
+    }
+}
+
+/**
+ * A report tree is a tree of report nodes, used by reporters to organize the coverage report.
+ */
+class ReportTree extends BaseTree {
+    constructor(root, childPrefix) {
+        super(root);
+
+        const maybePrefix = node => {
+            if (childPrefix && !node.isRoot()) {
+                node.path.unshift(childPrefix);
+            }
+        };
+        this.visit({
+            onDetail: maybePrefix,
+            onSummary(node) {
+                maybePrefix(node);
+                node.children.sort((a, b) => {
+                    const astr = a.path.toString();
+                    const bstr = b.path.toString();
+                    return astr < bstr
+                        ? -1
+                        : astr > bstr
+                        ? 1
+                        : /* istanbul ignore next */ 0;
+                });
+            }
+        });
+    }
+}
+
+/**
+ * A collection of utility functions useful for creating a report tree.
+ */
+const Util = {
+    addAllPaths(topPaths, nodeMap, path, node) {
+        const parent = Util.findOrCreateParent(
+            path.parent(),
+            nodeMap,
+            (parentPath, parent) => {
+                if (parentPath.hasParent()) {
+                    Util.addAllPaths(topPaths, nodeMap, parentPath, parent);
+                } else {
+                    topPaths.push(parent);
+                }
+            }
+        );
+
+        parent.addChild(node);
+    },
+
+    findCommonParent(paths) {
+        return paths.reduce(
+            (common, path) => common.commonPrefixPath(path),
+            paths[0] || new Path([])
+        );
+    },
+
+    findOrCreateParent(parentPath, nodeMap, created = () => {}) {
+        let parent = nodeMap[parentPath.toString()];
+
+        if (!parent) {
+            parent = new ReportNode(parentPath);
+            nodeMap[parentPath.toString()] = parent;
+            created(parentPath, parent);
+        }
+
+        return parent;
+    },
+
+    foldIntoOneDir(node, parent) {
+        const { children } = node;
+        if (children.length === 1 && !children[0].fileCoverage) {
+            children[0].parent = parent;
+            return Util.foldIntoOneDir(children[0], parent);
+        }
+        node.children = children.map(child => Util.foldIntoOneDir(child, node));
+        return node;
+    },
+
+    toDirParents(list) {
+        const nodeMap = Object.create(null);
+        list.forEach(o => {
+            const parent = Util.findOrCreateParent(o.path.parent(), nodeMap);
+            parent.addChild(new ReportNode(o.path, o.fileCoverage));
+        });
+
+        return Object.values(nodeMap);
+    },
+
+    pkgSummaryPrefix(dirParents, commonParent) {
+        if (!dirParents.some(dp => dp.path.length === 0)) {
+            return;
+        }
+
+        if (commonParent.length === 0) {
+            return 'root';
+        }
+
+        return commonParent.name();
+    }
+};
+
+/**
+ * Return a "flat" report tree. This tree contains all source files as direct children of
+ * of the root node, with no intermediate nodes.
+ */
+function getFlatTree(initialList /*, commonParent */) {
+    return new ReportTree(
+        ReportNode.createRoot(
+            initialList.map(
+                node => new ReportNode(node.path, node.fileCoverage)
+            )
+        )
+    );
+}
+
+/**
+ * Return a "package" report tree. This tree creates intermediate nodes for all directories
+ * that contain at least one source file, but skips (collapses) intermediate directories
+ * that only contain other directories.
+ */
+function getPkgTree(initialList, commonParent) {
+    const dirParents = Util.toDirParents(initialList);
+    if (dirParents.length === 1) {
+        return new ReportTree(dirParents[0]);
+    }
+
+    return new ReportTree(
+        ReportNode.createRoot(dirParents),
+        Util.pkgSummaryPrefix(dirParents, commonParent)
+    );
+}
+
+/**
+ * Return a "nested" report tree. This tree creates intermediate nodes for every subdirectory,
+ * similar to a standard file explorer.
+ */
+function getNestedTree(initialList /*, commonParent */) {
+    const nodeMap = Object.create(null);
+    const topPaths = [];
+    initialList.forEach(o => {
+        const node = new ReportNode(o.path, o.fileCoverage);
+        Util.addAllPaths(topPaths, nodeMap, o.path, node);
+    });
+
+    const topNodes = topPaths.map(node => Util.foldIntoOneDir(node));
+    if (topNodes.length === 1) {
+        return new ReportTree(topNodes[0]);
+    }
+
+    return new ReportTree(ReportNode.createRoot(topNodes));
+}
+
+module.exports = {
+    ReportNode,
+    ReportTree,
+    Util,
+    Path,
+    getFlatTree,
+    getPkgTree,
+    getNestedTree
+};

--- a/packages/istanbul-lib-report/summarizer.js
+++ b/packages/istanbul-lib-report/summarizer.js
@@ -1,3 +1,55 @@
 'use strict';
 
-module.exports = require('./lib/summarizer');
+const Path = require('./lib/path');
+const { ReportNode, ReportTree, Util } = require('./lib/summarizer-core');
+
+/**
+ * @module Summarizer
+ *
+ * A summarizer is a utility function that takes a list of files with code coverage and organizes
+ * it into a ReportTree object. How the nodes are organized determines how the reporter using the
+ * summarizer will structure its output.
+ *
+ * There are 3 built-in summarizers:
+ *
+ *  - `flat` produces a single root node containing all covered files, with no intermediate nodes
+ *    for folders.
+ *  - `pkg` collects covered files into their closest folders, collapsing folders that don't contain
+ *    any source files. Each intermediate node represents a folder containing source files.
+ *  - `nested` acts like a typical file explorer view, with intermediate nodes representing folders
+ *    (including folders that only contain other folders).
+ *
+ * Some (but not all) reporters allow you to pass a `summarizer:` option to control which summarizer
+ * function is used when creating the coverage report.
+ *
+ * In addition to these built-in summarizers, you can create your own summarizer function and pass
+ * it to a reporter. The summarizer function must return a `ReportTree` object, and it accepts
+ * an initial list of file entries (containing file coverage data and `Path` object). Look at the
+ * implementation of the existing summarizers in `lib/summarizer-core.js` for examples.
+ */
+
+module.exports = {
+    /**
+     * A report tree represents a collection of nodes, where each node represents an individual file
+     * with code coverage or a collection of files (usually a folder).
+     */
+    ReportTree,
+
+    /**
+     * Each report node contains a path and coverage information, along with references to its parent
+     * node and any child nodes.
+     */
+    ReportNode,
+
+    /**
+     * The Path utility class represents file paths as an array of path segments, and is used extensively
+     * in the ReportTree and ReportNode classes.
+     */
+    Path,
+
+    /**
+     * A collection of utility functions useful for collapsing, searching, and organizing report nodes while
+     * building a report tree.
+     */
+    Util
+};

--- a/packages/istanbul-lib-report/summarizer.js
+++ b/packages/istanbul-lib-report/summarizer.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/summarizer');

--- a/packages/istanbul-lib-report/test/context.test.js
+++ b/packages/istanbul-lib-report/test/context.test.js
@@ -63,4 +63,14 @@ describe('context', () => {
         const visitor = ctx.getVisitor({});
         assert.ok(typeof visitor.onStart === 'function');
     });
+    it('returns a report tree when passed a summarizer name', () => {
+        const ctx = new Context(optsEmptyCoverage);
+        const tree = ctx.getTree('nested');
+        assert.equal(typeof tree, 'object');
+    });
+    it('returns a report tree when passed a summarizer function', () => {
+        const ctx = new Context(optsEmptyCoverage);
+        const tree = ctx.getTree(() => ({ root: 'a valid tree' }));
+        assert.deepEqual(tree, { root: 'a valid tree' });
+    });
 });

--- a/packages/istanbul-lib-report/test/summarizer.test.js
+++ b/packages/istanbul-lib-report/test/summarizer.test.js
@@ -1,0 +1,16 @@
+'use strict';
+/* globals describe, it */
+
+const assert = require('chai').assert;
+const summarizer = require('../summarizer');
+
+describe('summarizer interface', () => {
+    it('exports the desired interface', () => {
+        // The "istanbul-lib-report/summarizer" entry point exports everything you need
+        // to build a custom summarizer function, which can be passed to a ReportBase subclass.
+        assert.isFunction(summarizer.ReportTree);
+        assert.isFunction(summarizer.ReportNode);
+        assert.isFunction(summarizer.Path);
+        assert.isObject(summarizer.Util);
+    });
+});

--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -252,7 +252,7 @@ function fixPct(metrics) {
 
 class HtmlReport extends ReportBase {
     constructor(opts) {
-        super();
+        super({ summarizer: opts.summarizer });
 
         this.verbose = opts.verbose;
         this.linkMapper = opts.linkMapper || standardLinkMapper;


### PR DESCRIPTION
### SUMMARY

Export a new interface that allows users to create their own custom summarize functions, and to use them when building custom reporters for istanbul (or when calling existing reporters). Today this isn't really possible because the user of `istanbul-lib-reports` can't get access to the underlying structures (like ReportTree) you need to build a summarizer.

An example of how an end-user could use this new interface:

``
import { create as createReport } from 'istanbul-reports';
import { createContext } from 'istanbul-lib-report';
import { ReportNode, ReportTree, Util } from 'istanbul-lib-report/summarizer';

// Custom summarizer: organize all files into two-deep subfolders from root.
function getTree(initialList, commonParent) {
    const nodeMap = Object.create(null);
    const topPaths = [];
    initialList.forEach(o => {
        const node = new ReportNode(o.path, o.fileCoverage);
        const parent = Util.findOrCreateParent(
            new Path(o.path.elements().slice(0, 2)),
            nodeMap,
            (parentPath, parent) => {
                topPaths.push(parent);
            }
        );
        parent.addChild(node);
    });

    return new ReportTree(ReportNode.createRoot(topPaths));
}

const context = createContext({ /* get a bunch of coverage data */ });
const report = createReport('html', { summarizer: getTree });
report.execute(context);
```

### DETAILS

I've put together my suggested implementation for this feature, a quick change list:

 - Allow the HTML reporter to accept a `summarizer` option.
 - Break up most of `summarizer-factory` into `summarizer-core`, pulling the utility functions into a `Util` object.
 - Allow the Context to take either a summarizer _name_, or a summarizer _function_ which will be executed instead.
 - Add a new top-level entry point `summarizer.js`, which re-exports pieces of `summarizer-core`.
 - Best-effort new descriptions of the different summarizer pieces and how to use them to create a custom summarizer.
 - I "un-privatized" the `_summary` field on ReportBase -- I think it's appropriate to allow custom subclasses of ReportBase to override the `_summary` field in their constructor, after calling the super constructor (or even for an end-user to construct a ReportBase object, and then override the field manually before calling `execute()`.)

### TESTING

I've tested this change using my desired new summarizer (see example above for something close to what I'm looking for), and the existing summarizers (`pkg`, `nested`, `flat`).  Added unit tests to get code coverage back to 100%, but am happy to add more if there's additional functionality I should test.
