### PR TITLE
Fix coverage.branchMap else location.

### DIFF
--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-instrument",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Core istanbul API for JS code coverage",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "src/index.js",

--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-instrument",
-  "version": "5.0.3",
+  "version": "5.0.2",
   "description": "Core istanbul API for JS code coverage",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "src/index.js",

--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -420,7 +420,7 @@ function coverIfBranches(path) {
     if (ignoreElse) {
         this.setAttr(n.alternate, 'skip-all', true);
     } else {
-        this.insertBranchCounter(path.get('alternate'), branch, n.loc);
+        this.insertBranchCounter(path.get('alternate'), branch);
     }
 }
 


### PR DESCRIPTION
The else statement in an if ... else statement is not correct. 
Input code:
`if (x) {
    output = x;
  }
  else {
    output = false;
  }`

Problem output:
`branchMap: ..."1": {
    "loc": {
        "start": {
            "line": 7,
            "column": 2
        },
        "end": {
            "line": 12,
            "column": 3
        }
    },
    "type": "if",
    "locations": [{
            "start": {
                "line": 7,
                "column": 2
            },
            "end": {
                "line": 12,
                "column": 3
            }
        }, {
            "start": {
                "line": 7, // PROBLEM
                "column": 2
            },
            "end": {
                "line": 12,
                "column": 3
            }
        }
    ],
    "line": 7
}`

Expected output:
`branchMap: ..."1": {
    "loc": {
        "start": {
            "line": 7,
            "column": 2
        },
        "end": {
            "line": 12,
            "column": 3
        }
    },
    "type": "if",
    "locations": [{
            "start": {
                "line": 7,
                "column": 2
            },
            "end": {
                "line": 12,
                "column": 3
            }
        }, {
            "start": {
                "line": 10, // CORRECT
                "column": 7
            },
            "end": {
                "line": 12,
                "column": 3
            }
        }
    ],
    "line": 7
}`

Caveats: Your testing code on fails to test the map properties, so I also omitted those tests because they are too far outside the scope of fixing this single bug. Cheerio to the team of my fave JavaScript coverage library. 