### PR TITLE
fix: handle reports with "loc" but no "decl"

### DIFF
--- a/packages/istanbul-reports/lib/html/annotator.js
+++ b/packages/istanbul-reports/lib/html/annotator.js
@@ -86,10 +86,13 @@ function annotateFunctions(fileCoverage, structuredText) {
     Object.entries(fnStats).forEach(([fName, count]) => {
         const meta = fnMeta[fName];
         const type = count > 0 ? 'yes' : 'no';
-        const startCol = meta.decl.start.column;
-        let endCol = meta.decl.end.column + 1;
-        const startLine = meta.decl.start.line;
-        const endLine = meta.decl.end.line;
+        // Some versions of the instrumenter in the wild populate 'func'
+        // but not 'decl':
+        const decl = meta.decl || meta.loc;
+        const startCol = decl.start.column;
+        let endCol = decl.end.column + 1;
+        const startLine = decl.start.line;
+        const endLine = decl.end.line;
         const openSpan =
             lt +
             'span class="' +

--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -8,6 +8,7 @@ const { ReportBase } = require('istanbul-lib-report');
 class LcovOnlyReport extends ReportBase {
     constructor(opts) {
         super();
+        opts = opts || {};
         this.file = opts.file || 'lcov.info';
         this.projectRoot = opts.projectRoot || process.cwd();
         this.contentWriter = null;
@@ -28,12 +29,15 @@ class LcovOnlyReport extends ReportBase {
         const summary = node.getCoverageSummary();
         const path = require('path');
 
-        writer.println('TN:'); //no test nam
+        writer.println('TN:');
         const fileName = path.relative(this.projectRoot, fc.path);
         writer.println('SF:' + fileName);
 
         Object.values(functionMap).forEach(meta => {
-            writer.println('FN:' + [meta.decl.start.line, meta.name].join(','));
+            // Some versions of the instrumenter in the wild populate 'loc'
+            // but not 'decl':
+            const decl = meta.decl || meta.loc;
+            writer.println('FN:' + [decl.start.line, meta.name].join(','));
         });
         writer.println('FNF:' + summary.functions.total);
         writer.println('FNH:' + summary.functions.covered);

--- a/packages/istanbul-reports/test/fixtures/github-322.json
+++ b/packages/istanbul-reports/test/fixtures/github-322.json
@@ -1,0 +1,28 @@
+{
+  "statementMap": {
+  },
+  "fnMap": {
+    "0": {
+      "name": "test",
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      }
+    }
+  },
+  "branchMap": {
+  },
+  "s": {
+  },
+  "f": {
+    "0": 0
+  },
+  "b": {
+  }
+}

--- a/packages/istanbul-reports/test/fixtures/specs/missing-decl.json
+++ b/packages/istanbul-reports/test/fixtures/specs/missing-decl.json
@@ -1,0 +1,1615 @@
+{
+    "title": "100% line coverage, missing branch coverage",
+    "textReportExpected": "----------|---------|----------|---------|---------|-------------------\nFile      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s \n----------|---------|----------|---------|---------|-------------------\n\u001b[32;1mAll files\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m                 \u001b[0m \n\u001b[32;1m index.js\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m   95.34\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[32;1m    100\u001b[0m | \u001b[33;1m21,29            \u001b[0m \n----------|---------|----------|---------|---------|-------------------\n",
+    "lcovonlyExpected": "TN:\nSF:\nFN:12,TestExclude\nFN:50,(anonymous_1)\nFN:52,(anonymous_2)\nFN:61,(anonymous_3)\nFN:71,(anonymous_4)\nFN:84,prepGlobPatterns\nFN:85,(anonymous_6)\nFN:100,(anonymous_7)\nFNF:8\nFNH:8\nFNDA:21,TestExclude\nFNDA:21,(anonymous_1)\nFNDA:95,(anonymous_2)\nFNDA:56,(anonymous_3)\nFNDA:7,(anonymous_4)\nFNDA:26,prepGlobPatterns\nFNDA:105,(anonymous_6)\nFNDA:21,(anonymous_7)\nDA:1,1\nDA:2,1\nDA:3,1\nDA:4,1\nDA:5,1\nDA:13,21\nDA:21,21\nDA:22,21\nDA:24,21\nDA:25,7\nDA:28,21\nDA:29,15\nDA:32,21\nDA:33,5\nDA:35,16\nDA:38,21\nDA:39,5\nDA:42,21\nDA:50,1\nDA:51,21\nDA:52,21\nDA:53,95\nDA:55,95\nDA:56,95\nDA:58,21\nDA:61,1\nDA:62,56\nDA:65,56\nDA:67,55\nDA:68,55\nDA:71,1\nDA:72,7\nDA:76,7\nDA:77,6\nDA:78,6\nDA:80,1\nDA:85,26\nDA:87,105\nDA:88,39\nDA:92,105\nDA:93,50\nDA:96,105\nDA:100,1\nDA:101,21\nDA:104,1\nDA:113,1\nLF:46\nLH:46\nBRDA:21,0,0,1\nBRDA:21,0,1,20\nBRDA:21,1,0,1\nBRDA:21,1,1,0\nBRDA:22,2,0,1\nBRDA:22,2,1,20\nBRDA:24,3,0,7\nBRDA:24,3,1,14\nBRDA:24,4,0,21\nBRDA:24,4,1,18\nBRDA:24,4,2,15\nBRDA:28,5,0,15\nBRDA:28,5,1,6\nBRDA:28,6,0,21\nBRDA:28,6,1,8\nBRDA:29,7,0,15\nBRDA:29,7,1,0\nBRDA:32,8,0,5\nBRDA:32,8,1,16\nBRDA:32,9,0,21\nBRDA:32,9,1,5\nBRDA:38,10,0,5\nBRDA:38,10,1,16\nBRDA:38,11,0,21\nBRDA:38,11,1,20\nBRDA:55,12,0,1\nBRDA:55,12,1,94\nBRDA:62,13,0,56\nBRDA:62,13,1,56\nBRDA:65,14,0,1\nBRDA:65,14,1,55\nBRDA:68,15,0,55\nBRDA:68,15,1,15\nBRDA:68,15,2,50\nBRDA:76,16,0,6\nBRDA:76,16,1,1\nBRDA:76,17,0,7\nBRDA:76,17,1,7\nBRDA:76,17,2,6\nBRDA:87,18,0,39\nBRDA:87,18,1,66\nBRDA:92,19,0,50\nBRDA:92,19,1,55\nBRF:43\nBRH:41\nend_of_record\n",
+    "htmlSpaFiles": ["index.js.html", "index.html"],
+    "htmlSpaCoverageData": {
+        "file": "",
+        "isEmpty": false,
+        "metrics": {
+            "statements": {
+                "total": 50,
+                "covered": 50,
+                "missed": 0,
+                "skipped": 0,
+                "pct": 100,
+                "classForPercent": "high"
+            },
+            "branches": {
+                "total": 43,
+                "covered": 41,
+                "missed": 2,
+                "skipped": 0,
+                "pct": 95.34,
+                "classForPercent": "high"
+            },
+            "functions": {
+                "total": 8,
+                "covered": 8,
+                "missed": 0,
+                "skipped": 0,
+                "pct": 100,
+                "classForPercent": "high"
+            },
+            "lines": {
+                "total": 46,
+                "covered": 46,
+                "missed": 0,
+                "skipped": 0,
+                "pct": 100,
+                "classForPercent": "high"
+            }
+        },
+        "children": [
+            {
+                "file": "index.js",
+                "isEmpty": false,
+                "metrics": {
+                    "statements": {
+                        "total": 50,
+                        "covered": 50,
+                        "missed": 0,
+                        "skipped": 0,
+                        "pct": 100,
+                        "classForPercent": "high"
+                    },
+                    "branches": {
+                        "total": 43,
+                        "covered": 41,
+                        "missed": 2,
+                        "skipped": 0,
+                        "pct": 95.34,
+                        "classForPercent": "high"
+                    },
+                    "functions": {
+                        "total": 8,
+                        "covered": 8,
+                        "missed": 0,
+                        "skipped": 0,
+                        "pct": 100,
+                        "classForPercent": "high"
+                    },
+                    "lines": {
+                        "total": 46,
+                        "covered": 46,
+                        "missed": 0,
+                        "skipped": 0,
+                        "pct": 100,
+                        "classForPercent": "high"
+                    }
+                },
+                "children": false
+            }
+        ]
+    },
+    "map": {
+        "/Users/benjamincoe/oss/test-exclude/index.js": {
+            "path": "/Users/benjamincoe/oss/test-exclude/index.js",
+            "statementMap": {
+                "0": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 39
+                    }
+                },
+                "1": {
+                    "start": {
+                        "line": 2,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 32
+                    }
+                },
+                "2": {
+                    "start": {
+                        "line": 3,
+                        "column": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 40
+                    }
+                },
+                "3": {
+                    "start": {
+                        "line": 4,
+                        "column": 13
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 28
+                    }
+                },
+                "4": {
+                    "start": {
+                        "line": 5,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 40
+                    }
+                },
+                "5": {
+                    "start": {
+                        "line": 13,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 19,
+                        "column": 10
+                    }
+                },
+                "6": {
+                    "start": {
+                        "line": 21,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 81
+                    }
+                },
+                "7": {
+                    "start": {
+                        "line": 21,
+                        "column": 40
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 81
+                    }
+                },
+                "8": {
+                    "start": {
+                        "line": 22,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 69
+                    }
+                },
+                "9": {
+                    "start": {
+                        "line": 22,
+                        "column": 40
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 69
+                    }
+                },
+                "10": {
+                    "start": {
+                        "line": 24,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 26,
+                        "column": 3
+                    }
+                },
+                "11": {
+                    "start": {
+                        "line": 25,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 25,
+                        "column": 63
+                    }
+                },
+                "12": {
+                    "start": {
+                        "line": 28,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 30,
+                        "column": 3
+                    }
+                },
+                "13": {
+                    "start": {
+                        "line": 29,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 29,
+                        "column": 54
+                    }
+                },
+                "14": {
+                    "start": {
+                        "line": 32,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 36,
+                        "column": 3
+                    }
+                },
+                "15": {
+                    "start": {
+                        "line": 33,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 57
+                    }
+                },
+                "16": {
+                    "start": {
+                        "line": 35,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 35,
+                        "column": 24
+                    }
+                },
+                "17": {
+                    "start": {
+                        "line": 38,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 40,
+                        "column": 3
+                    }
+                },
+                "18": {
+                    "start": {
+                        "line": 39,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 39,
+                        "column": 43
+                    }
+                },
+                "19": {
+                    "start": {
+                        "line": 42,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 44,
+                        "column": 3
+                    }
+                },
+                "20": {
+                    "start": {
+                        "line": 50,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 59,
+                        "column": 1
+                    }
+                },
+                "21": {
+                    "start": {
+                        "line": 51,
+                        "column": 29
+                    },
+                    "end": {
+                        "line": 51,
+                        "column": 34
+                    }
+                },
+                "22": {
+                    "start": {
+                        "line": 52,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 57,
+                        "column": 4
+                    }
+                },
+                "23": {
+                    "start": {
+                        "line": 53,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 54,
+                        "column": 71
+                    }
+                },
+                "24": {
+                    "start": {
+                        "line": 55,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 55,
+                        "column": 44
+                    }
+                },
+                "25": {
+                    "start": {
+                        "line": 55,
+                        "column": 17
+                    },
+                    "end": {
+                        "line": 55,
+                        "column": 44
+                    }
+                },
+                "26": {
+                    "start": {
+                        "line": 56,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 56,
+                        "column": 19
+                    }
+                },
+                "27": {
+                    "start": {
+                        "line": 58,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 58,
+                        "column": 29
+                    }
+                },
+                "28": {
+                    "start": {
+                        "line": 61,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 69,
+                        "column": 1
+                    }
+                },
+                "29": {
+                    "start": {
+                        "line": 62,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 62,
+                        "column": 56
+                    }
+                },
+                "30": {
+                    "start": {
+                        "line": 65,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 65,
+                        "column": 67
+                    }
+                },
+                "31": {
+                    "start": {
+                        "line": 65,
+                        "column": 55
+                    },
+                    "end": {
+                        "line": 65,
+                        "column": 67
+                    }
+                },
+                "32": {
+                    "start": {
+                        "line": 67,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 67,
+                        "column": 43
+                    }
+                },
+                "33": {
+                    "start": {
+                        "line": 68,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 68,
+                        "column": 143
+                    }
+                },
+                "34": {
+                    "start": {
+                        "line": 71,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 82,
+                        "column": 1
+                    }
+                },
+                "35": {
+                    "start": {
+                        "line": 72,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 74,
+                        "column": 4
+                    }
+                },
+                "36": {
+                    "start": {
+                        "line": 76,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 81,
+                        "column": 3
+                    }
+                },
+                "37": {
+                    "start": {
+                        "line": 77,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 77,
+                        "column": 27
+                    }
+                },
+                "38": {
+                    "start": {
+                        "line": 78,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 78,
+                        "column": 23
+                    }
+                },
+                "39": {
+                    "start": {
+                        "line": 80,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 80,
+                        "column": 13
+                    }
+                },
+                "40": {
+                    "start": {
+                        "line": 85,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 97,
+                        "column": 8
+                    }
+                },
+                "41": {
+                    "start": {
+                        "line": 87,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 89,
+                        "column": 5
+                    }
+                },
+                "42": {
+                    "start": {
+                        "line": 88,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 88,
+                        "column": 64
+                    }
+                },
+                "43": {
+                    "start": {
+                        "line": 92,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 94,
+                        "column": 5
+                    }
+                },
+                "44": {
+                    "start": {
+                        "line": 93,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 93,
+                        "column": 60
+                    }
+                },
+                "45": {
+                    "start": {
+                        "line": 96,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 96,
+                        "column": 33
+                    }
+                },
+                "46": {
+                    "start": {
+                        "line": 100,
+                        "column": 17
+                    },
+                    "end": {
+                        "line": 102,
+                        "column": 1
+                    }
+                },
+                "47": {
+                    "start": {
+                        "line": 101,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 101,
+                        "column": 30
+                    }
+                },
+                "48": {
+                    "start": {
+                        "line": 104,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 111,
+                        "column": 1
+                    }
+                },
+                "49": {
+                    "start": {
+                        "line": 113,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 113,
+                        "column": 27
+                    }
+                }
+            },
+            "fnMap": {
+                "0": {
+                    "name": "TestExclude",
+                    "loc": {
+                        "start": {
+                            "line": 12,
+                            "column": 28
+                        },
+                        "end": {
+                            "line": 45,
+                            "column": 1
+                        }
+                    },
+                    "line": 12
+                },
+                "1": {
+                    "name": "(anonymous_1)",
+                    "decl": {
+                        "start": {
+                            "line": 50,
+                            "column": 51
+                        },
+                        "end": {
+                            "line": 50,
+                            "column": 52
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 50,
+                            "column": 63
+                        },
+                        "end": {
+                            "line": 59,
+                            "column": 1
+                        }
+                    },
+                    "line": 50
+                },
+                "2": {
+                    "name": "(anonymous_2)",
+                    "decl": {
+                        "start": {
+                            "line": 52,
+                            "column": 37
+                        },
+                        "end": {
+                            "line": 52,
+                            "column": 38
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 52,
+                            "column": 50
+                        },
+                        "end": {
+                            "line": 57,
+                            "column": 3
+                        }
+                    },
+                    "line": 52
+                },
+                "3": {
+                    "name": "(anonymous_3)",
+                    "decl": {
+                        "start": {
+                            "line": 61,
+                            "column": 41
+                        },
+                        "end": {
+                            "line": 61,
+                            "column": 42
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 61,
+                            "column": 70
+                        },
+                        "end": {
+                            "line": 69,
+                            "column": 1
+                        }
+                    },
+                    "line": 61
+                },
+                "4": {
+                    "name": "(anonymous_4)",
+                    "decl": {
+                        "start": {
+                            "line": 71,
+                            "column": 32
+                        },
+                        "end": {
+                            "line": 71,
+                            "column": 33
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 71,
+                            "column": 53
+                        },
+                        "end": {
+                            "line": 82,
+                            "column": 1
+                        }
+                    },
+                    "line": 71
+                },
+                "5": {
+                    "name": "prepGlobPatterns",
+                    "decl": {
+                        "start": {
+                            "line": 84,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 84,
+                            "column": 25
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 84,
+                            "column": 37
+                        },
+                        "end": {
+                            "line": 98,
+                            "column": 1
+                        }
+                    },
+                    "line": 84
+                },
+                "6": {
+                    "name": "(anonymous_6)",
+                    "decl": {
+                        "start": {
+                            "line": 85,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 85,
+                            "column": 26
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 85,
+                            "column": 52
+                        },
+                        "end": {
+                            "line": 97,
+                            "column": 3
+                        }
+                    },
+                    "line": 85
+                },
+                "7": {
+                    "name": "(anonymous_7)",
+                    "decl": {
+                        "start": {
+                            "line": 100,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 100,
+                            "column": 18
+                        }
+                    },
+                    "loc": {
+                        "start": {
+                            "line": 100,
+                            "column": 33
+                        },
+                        "end": {
+                            "line": 102,
+                            "column": 1
+                        }
+                    },
+                    "line": 100
+                }
+            },
+            "branchMap": {
+                "0": {
+                    "loc": {
+                        "start": {
+                            "line": 21,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 21,
+                            "column": 81
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 21,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 81
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 21,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 81
+                            }
+                        }
+                    ],
+                    "line": 21
+                },
+                "1": {
+                    "loc": {
+                        "start": {
+                            "line": 21,
+                            "column": 55
+                        },
+                        "end": {
+                            "line": 21,
+                            "column": 81
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 21,
+                                "column": 55
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 69
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 21,
+                                "column": 73
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 81
+                            }
+                        }
+                    ],
+                    "line": 21
+                },
+                "2": {
+                    "loc": {
+                        "start": {
+                            "line": 22,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 22,
+                            "column": 69
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 22,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 69
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 22,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 69
+                            }
+                        }
+                    ],
+                    "line": 22
+                },
+                "3": {
+                    "loc": {
+                        "start": {
+                            "line": 24,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 26,
+                            "column": 3
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 24,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 3
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 24,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 3
+                            }
+                        }
+                    ],
+                    "line": 24
+                },
+                "4": {
+                    "loc": {
+                        "start": {
+                            "line": 24,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 54
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 24,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 19
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 24,
+                                "column": 23
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 36
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 24,
+                                "column": 40
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 54
+                            }
+                        }
+                    ],
+                    "line": 24
+                },
+                "5": {
+                    "loc": {
+                        "start": {
+                            "line": 28,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 30,
+                            "column": 3
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 28,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 3
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 28,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 3
+                            }
+                        }
+                    ],
+                    "line": 28
+                },
+                "6": {
+                    "loc": {
+                        "start": {
+                            "line": 28,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 51
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 28,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 28,
+                                "column": 19
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 28,
+                                "column": 23
+                            },
+                            "end": {
+                                "line": 28,
+                                "column": 51
+                            }
+                        }
+                    ],
+                    "line": 28
+                },
+                "7": {
+                    "loc": {
+                        "start": {
+                            "line": 29,
+                            "column": 19
+                        },
+                        "end": {
+                            "line": 29,
+                            "column": 54
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 29,
+                                "column": 19
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 44
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 29,
+                                "column": 48
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 54
+                            }
+                        }
+                    ],
+                    "line": 29
+                },
+                "8": {
+                    "loc": {
+                        "start": {
+                            "line": 32,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 36,
+                            "column": 3
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 32,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 3
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 32,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 3
+                            }
+                        }
+                    ],
+                    "line": 32
+                },
+                "9": {
+                    "loc": {
+                        "start": {
+                            "line": 32,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 32,
+                            "column": 45
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 32,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 32,
+                                "column": 18
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 32,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 32,
+                                "column": 45
+                            }
+                        }
+                    ],
+                    "line": 32
+                },
+                "10": {
+                    "loc": {
+                        "start": {
+                            "line": 38,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 40,
+                            "column": 3
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 38,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 40,
+                                "column": 3
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 38,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 40,
+                                "column": 3
+                            }
+                        }
+                    ],
+                    "line": 38
+                },
+                "11": {
+                    "loc": {
+                        "start": {
+                            "line": 38,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 38,
+                            "column": 93
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 38,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 40
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 38,
+                                "column": 44
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 93
+                            }
+                        }
+                    ],
+                    "line": 38
+                },
+                "12": {
+                    "loc": {
+                        "start": {
+                            "line": 55,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 55,
+                            "column": 44
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 55,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 55,
+                                "column": 44
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 55,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 55,
+                                "column": 44
+                            }
+                        }
+                    ],
+                    "line": 55
+                },
+                "13": {
+                    "loc": {
+                        "start": {
+                            "line": 62,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 62,
+                            "column": 56
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 62,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 62,
+                                "column": 19
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 62,
+                                "column": 23
+                            },
+                            "end": {
+                                "line": 62,
+                                "column": 56
+                            }
+                        }
+                    ],
+                    "line": 62
+                },
+                "14": {
+                    "loc": {
+                        "start": {
+                            "line": 65,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 65,
+                            "column": 67
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 65,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 65,
+                                "column": 67
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 65,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 65,
+                                "column": 67
+                            }
+                        }
+                    ],
+                    "line": 65
+                },
+                "15": {
+                    "loc": {
+                        "start": {
+                            "line": 68,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 68,
+                            "column": 143
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 68,
+                                "column": 10
+                            },
+                            "end": {
+                                "line": 68,
+                                "column": 23
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 68,
+                                "column": 27
+                            },
+                            "end": {
+                                "line": 68,
+                                "column": 82
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 68,
+                                "column": 87
+                            },
+                            "end": {
+                                "line": 68,
+                                "column": 143
+                            }
+                        }
+                    ],
+                    "line": 68
+                },
+                "16": {
+                    "loc": {
+                        "start": {
+                            "line": 76,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 81,
+                            "column": 3
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 76,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 81,
+                                "column": 3
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 76,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 81,
+                                "column": 3
+                            }
+                        }
+                    ],
+                    "line": 76
+                },
+                "17": {
+                    "loc": {
+                        "start": {
+                            "line": 76,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 76,
+                            "column": 65
+                        }
+                    },
+                    "type": "binary-expr",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 76,
+                                "column": 6
+                            },
+                            "end": {
+                                "line": 76,
+                                "column": 13
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 76,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 76,
+                                "column": 29
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 76,
+                                "column": 33
+                            },
+                            "end": {
+                                "line": 76,
+                                "column": 65
+                            }
+                        }
+                    ],
+                    "line": 76
+                },
+                "18": {
+                    "loc": {
+                        "start": {
+                            "line": 87,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 89,
+                            "column": 5
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 87,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 89,
+                                "column": 5
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 87,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 89,
+                                "column": 5
+                            }
+                        }
+                    ],
+                    "line": 87
+                },
+                "19": {
+                    "loc": {
+                        "start": {
+                            "line": 92,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 94,
+                            "column": 5
+                        }
+                    },
+                    "type": "if",
+                    "locations": [
+                        {
+                            "start": {
+                                "line": 92,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 94,
+                                "column": 5
+                            }
+                        },
+                        {
+                            "start": {
+                                "line": 92,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 94,
+                                "column": 5
+                            }
+                        }
+                    ],
+                    "line": 92
+                }
+            },
+            "s": {
+                "0": 1,
+                "1": 1,
+                "2": 1,
+                "3": 1,
+                "4": 1,
+                "5": 21,
+                "6": 21,
+                "7": 1,
+                "8": 21,
+                "9": 1,
+                "10": 21,
+                "11": 7,
+                "12": 21,
+                "13": 15,
+                "14": 21,
+                "15": 5,
+                "16": 16,
+                "17": 21,
+                "18": 5,
+                "19": 21,
+                "20": 1,
+                "21": 21,
+                "22": 21,
+                "23": 95,
+                "24": 95,
+                "25": 1,
+                "26": 95,
+                "27": 21,
+                "28": 1,
+                "29": 56,
+                "30": 56,
+                "31": 1,
+                "32": 55,
+                "33": 55,
+                "34": 1,
+                "35": 7,
+                "36": 7,
+                "37": 6,
+                "38": 6,
+                "39": 1,
+                "40": 26,
+                "41": 105,
+                "42": 39,
+                "43": 105,
+                "44": 50,
+                "45": 105,
+                "46": 1,
+                "47": 21,
+                "48": 1,
+                "49": 1
+            },
+            "f": {
+                "0": 21,
+                "1": 21,
+                "2": 95,
+                "3": 56,
+                "4": 7,
+                "5": 26,
+                "6": 105,
+                "7": 21
+            },
+            "b": {
+                "0": [1, 20],
+                "1": [1, 0],
+                "2": [1, 20],
+                "3": [7, 14],
+                "4": [21, 18, 15],
+                "5": [15, 6],
+                "6": [21, 8],
+                "7": [15, 0],
+                "8": [5, 16],
+                "9": [21, 5],
+                "10": [5, 16],
+                "11": [21, 20],
+                "12": [1, 94],
+                "13": [56, 56],
+                "14": [1, 55],
+                "15": [55, 15, 50],
+                "16": [6, 1],
+                "17": [7, 7, 6],
+                "18": [39, 66],
+                "19": [50, 55]
+            },
+            "_coverageSchema": "332fd63041d2c1bcb487cc26dd0d5f7d97098a6c",
+            "hash": "f56f8d0db960f08dcdda97d0882cfd589e74eae5",
+            "contentHash": "4437193939a265a773fe2ec1a2d065a3_10.2.0"
+        }
+    }
+}

--- a/packages/istanbul-reports/test/html/annotator.js
+++ b/packages/istanbul-reports/test/html/annotator.js
@@ -69,5 +69,17 @@ describe('annotator', () => {
                 'if (cond1 &amp;&amp; <span class="branch-0 cbranch-no" title="branch not covered" >cond2) {</span>'
             );
         });
+
+        // see: https://github.com/istanbuljs/istanbuljs/pull/322
+        it('handles fnMap with missing decl', () => {
+            const annotated = annotator(getFixture('github-322'), {
+                getSource() {
+                    return '  function test () {};';
+                }
+            });
+            annotated.annotatedCode[0].should.equal(
+                '<span class="fstat-no" title="function not covered" >  function test () {};</span>'
+            );
+        });
     });
 });

--- a/packages/istanbul-reports/test/lcovonly/index.js
+++ b/packages/istanbul-reports/test/lcovonly/index.js
@@ -1,0 +1,55 @@
+'use strict';
+/* globals describe, it, beforeEach, before, after */
+const fs = require('fs');
+const path = require('path');
+const isWindows = require('is-windows');
+const FileWriter = require('istanbul-lib-report/lib/file-writer');
+const istanbulLibReport = require('istanbul-lib-report');
+const istanbulLibCoverage = require('istanbul-lib-coverage');
+const LcovOnlyReport = require('../../lib/lcovonly/index');
+
+require('chai').should();
+
+describe('LcovOnlyReport', () => {
+    before(() => {
+        FileWriter.startCapture();
+    });
+    after(() => {
+        FileWriter.stopCapture();
+    });
+    beforeEach(() => {
+        FileWriter.resetOutput();
+    });
+
+    function createTest(file) {
+        const fixture = require(path.resolve(
+            __dirname,
+            '../fixtures/specs/' + file
+        ));
+        it(fixture.title, function() {
+            if (isWindows()) {
+                // appveyor does not render console color.
+                return this.skip();
+            }
+            const context = istanbulLibReport.createContext({
+                dir: './',
+                coverageMap: istanbulLibCoverage.createCoverageMap(fixture.map)
+            });
+            const tree = context.getTree('pkg');
+            const report = new LcovOnlyReport(fixture.opts);
+            tree.visit(report, context);
+            const output = FileWriter.getOutput().replace(/SF:.*/, 'SF:');
+            if (fixture.lcovonlyExpected) {
+                output.should.equal(fixture.lcovonlyExpected);
+            }
+        });
+    }
+
+    fs.readdirSync(path.resolve(__dirname, '../fixtures/specs')).forEach(
+        file => {
+            if (file.indexOf('.json') !== -1) {
+                createTest(file);
+            }
+        }
+    );
+});


### PR DESCRIPTION
This appears to happen with reports output by karma, let's just deal with it.