### PR TITLE
Report Logic Truthiness: Port over coverage lib changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test nyc mocha --timeout 30000 packages/*/test{,/*}.js",
     "posttest": "eslint .",
-    "fix": "eslint .",
+    "fix": "eslint . --fix",
     "postinstall": "bash scripts/install.sh"
   },
   "repository": {

--- a/packages/istanbul-lib-coverage/lib/coverage-summary.js
+++ b/packages/istanbul-lib-coverage/lib/coverage-summary.js
@@ -64,12 +64,20 @@ class CoverageSummary {
      * @param {CoverageSummary} obj - another coverage summary object
      */
     merge(obj) {
-        const keys = ['lines', 'statements', 'branches', 'functions'];
+        const keys = [
+            'lines',
+            'statements',
+            'branches',
+            'functions',
+            'branchesTrue'
+        ];
         keys.forEach(key => {
-            this[key].total += obj[key].total;
-            this[key].covered += obj[key].covered;
-            this[key].skipped += obj[key].skipped;
-            this[key].pct = percent(this[key].covered, this[key].total);
+            if (obj[key]) {
+                this[key].total += obj[key].total;
+                this[key].covered += obj[key].covered;
+                this[key].skipped += obj[key].skipped;
+                this[key].pct = percent(this[key].covered, this[key].total);
+            }
         });
 
         return this;

--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -17,8 +17,7 @@ function emptyCoverage(filePath) {
         branchMap: {},
         s: {},
         f: {},
-        b: {},
-        bT: {}
+        b: {}
     };
 }
 
@@ -32,8 +31,7 @@ function assertValidObject(obj) {
         obj.branchMap &&
         obj.s &&
         obj.f &&
-        obj.b &&
-        obj.bT;
+        obj.b;
     if (!valid) {
         throw new Error(
             'Invalid file coverage object, missing keys, found:' +
@@ -239,7 +237,9 @@ class FileCoverage {
         this.data.b = hits;
         this.data.branchMap = map;
 
-        if (this.bT || other.bT) {
+        // Tracking additional information about branch truthiness
+        // can be optionally enabled:
+        if (this.bT && other.bT) {
             [hits, map] = mergeProp(
                 this.bT,
                 this.branchMap,
@@ -297,9 +297,13 @@ class FileCoverage {
         Object.keys(branches).forEach(b => {
             branches[b].fill(0);
         });
-        Object.keys(branchesTrue).forEach(bT => {
-            branchesTrue[bT].fill(0);
-        });
+        // Tracking additional information about branch truthiness
+        // can be optionally enabled:
+        if (branchesTrue) {
+            Object.keys(branchesTrue).forEach(bT => {
+                branchesTrue[bT].fill(0);
+            });
+        }
     }
 
     /**
@@ -312,7 +316,11 @@ class FileCoverage {
         ret.functions = this.computeSimpleTotals('f', 'fnMap');
         ret.statements = this.computeSimpleTotals('s', 'statementMap');
         ret.branches = this.computeBranchTotals('b');
-        ret.branchesTrue = this.computeBranchTotals('bT');
+        // Tracking additional information about branch truthiness
+        // can be optionally enabled:
+        if (this['bt']) {
+            ret.branchesTrue = this.computeBranchTotals('bT');
+        }
         return new CoverageSummary(ret);
     }
 }

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -129,7 +129,6 @@ describe('base coverage', () => {
         assert.ok(bc.s);
         assert.ok(bc.f);
         assert.ok(bc.b);
-        assert.ok(bc.bT);
         assert.ok(bc.getLineCoverage());
         assert.equal(bc.path, '/path/to/file');
     });
@@ -150,6 +149,343 @@ describe('base coverage', () => {
     });
 
     it('merges another file coverage correctly', () => {
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+        const template = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 1, 1, 100),
+                1: loc(2, 1, 2, 50),
+                2: loc(2, 51, 2, 100),
+                3: loc(2, 101, 3, 100)
+            },
+            fnMap: {
+                0: {
+                    name: 'foobar',
+                    line: 1,
+                    loc: loc(1, 1, 1, 50)
+                }
+            },
+            branchMap: {
+                0: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
+                }
+            },
+            s: {
+                0: 0,
+                1: 0,
+                2: 0,
+                3: 0
+            },
+            f: {
+                0: 0
+            },
+            b: {
+                0: [0, 0]
+            }
+        });
+        const clone = function(obj) {
+            return JSON.parse(JSON.stringify(obj));
+        };
+        const c1 = new FileCoverage(clone(template));
+        const c2 = new FileCoverage(clone(template));
+        let summary;
+
+        c1.s[0] = 1;
+        c1.f[0] = 1;
+        c1.b[0][0] = 1;
+
+        c2.s[1] = 1;
+        c2.f[0] = 1;
+        c2.b[0][1] = 2;
+        summary = c1.toSummary();
+        assert.ok(summary instanceof CoverageSummary);
+        assert.deepEqual(summary.statements, {
+            total: 4,
+            covered: 1,
+            skipped: 0,
+            pct: 25
+        });
+        assert.deepEqual(summary.lines, {
+            total: 2,
+            covered: 1,
+            skipped: 0,
+            pct: 50
+        });
+        assert.deepEqual(summary.functions, {
+            total: 1,
+            covered: 1,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.branches, {
+            total: 2,
+            covered: 1,
+            skipped: 0,
+            pct: 50
+        });
+
+        c1.merge(c2);
+        summary = c1.toSummary();
+        assert.deepEqual(summary.statements, {
+            total: 4,
+            covered: 2,
+            skipped: 0,
+            pct: 50
+        });
+        assert.deepEqual(summary.lines, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.functions, {
+            total: 1,
+            covered: 1,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.branches, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+
+        assert.equal(c1.s[0], 1);
+        assert.equal(c1.s[1], 1);
+        assert.equal(c1.f[0], 2);
+        assert.equal(c1.b[0][0], 1);
+        assert.equal(c1.b[0][1], 2);
+    });
+
+    it('merges another file coverage with different starting indices', () => {
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+        const template1 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 1, 1, 100),
+                1: loc(2, 1, 2, 50),
+                2: loc(2, 51, 2, 100),
+                3: loc(2, 101, 3, 100)
+            },
+            fnMap: {
+                0: {
+                    name: 'foobar',
+                    line: 1,
+                    loc: loc(1, 1, 1, 50)
+                }
+            },
+            branchMap: {
+                0: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
+                }
+            },
+            s: {
+                0: 0,
+                1: 0,
+                2: 0,
+                3: 0
+            },
+            f: {
+                0: 0
+            },
+            b: {
+                0: [0, 0]
+            }
+        });
+        const template2 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                1: loc(1, 1, 1, 100),
+                2: loc(2, 1, 2, 50),
+                3: loc(2, 51, 2, 100),
+                4: loc(2, 101, 3, 100)
+            },
+            fnMap: {
+                1: {
+                    name: 'foobar',
+                    line: 1,
+                    loc: loc(1, 1, 1, 50)
+                }
+            },
+            branchMap: {
+                1: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
+                }
+            },
+            s: {
+                1: 0,
+                2: 0,
+                3: 0,
+                4: 0
+            },
+            f: {
+                1: 0
+            },
+            b: {
+                1: [0, 0]
+            }
+        });
+        const clone = function(obj) {
+            return JSON.parse(JSON.stringify(obj));
+        };
+        const c1 = new FileCoverage(clone(template1));
+        const c2 = new FileCoverage(clone(template2));
+        let summary;
+
+        c1.s[0] = 1;
+        c1.f[0] = 1;
+        c1.b[0][0] = 1;
+
+        c2.s[2] = 1;
+        c2.f[1] = 1;
+        c2.b[1][1] = 2;
+        summary = c1.toSummary();
+        assert.ok(summary instanceof CoverageSummary);
+        assert.deepEqual(summary.statements, {
+            total: 4,
+            covered: 1,
+            skipped: 0,
+            pct: 25
+        });
+        assert.deepEqual(summary.lines, {
+            total: 2,
+            covered: 1,
+            skipped: 0,
+            pct: 50
+        });
+        assert.deepEqual(summary.functions, {
+            total: 1,
+            covered: 1,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.branches, {
+            total: 2,
+            covered: 1,
+            skipped: 0,
+            pct: 50
+        });
+
+        c1.merge(c2);
+        summary = c1.toSummary();
+        assert.deepEqual(summary.statements, {
+            total: 4,
+            covered: 2,
+            skipped: 0,
+            pct: 50
+        });
+        assert.deepEqual(summary.lines, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.functions, {
+            total: 1,
+            covered: 1,
+            skipped: 0,
+            pct: 100
+        });
+        assert.deepEqual(summary.branches, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+
+        assert.equal(c1.s[0], 1);
+        assert.equal(c1.s[1], 1);
+        assert.equal(c1.f[0], 2);
+        assert.equal(c1.b[0][0], 1);
+        assert.equal(c1.b[0][1], 2);
+    });
+
+    it('drops all data during merges', () => {
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+        const template = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                1: loc(1, 1, 1, 100),
+                2: loc(2, 1, 2, 50),
+                3: loc(2, 51, 2, 100),
+                4: loc(2, 101, 3, 100)
+            },
+            fnMap: {
+                1: {
+                    name: 'foobar',
+                    line: 1,
+                    loc: loc(1, 1, 1, 50)
+                }
+            },
+            branchMap: {
+                1: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
+                }
+            },
+            s: {
+                1: 0,
+                2: 0,
+                3: 0,
+                4: 0
+            },
+            f: {
+                1: 0
+            },
+            b: {
+                1: [0, 0]
+            }
+        });
+        const clone = function(obj) {
+            return JSON.parse(JSON.stringify(obj));
+        };
+        const createCoverage = all => {
+            const data = clone(template);
+            if (all) {
+                data.all = true;
+            } else {
+                data.s[1] = 1;
+                data.f[1] = 1;
+                data.b[1][0] = 1;
+            }
+
+            return new FileCoverage(data);
+        };
+
+        const expected = createCoverage().data;
+        // Get non-all data regardless of merge order
+        let cov = createCoverage(true);
+        cov.merge(createCoverage());
+        assert.deepEqual(cov.data, expected);
+        cov = createCoverage();
+        cov.merge(createCoverage(true));
+        assert.deepEqual(cov.data, expected);
+    });
+
+    it('merges another file coverage that tracks logical truthiness', () => {
         const loc = function(sl, sc, el, ec) {
             return {
                 start: { line: sl, column: sc },
@@ -273,237 +609,6 @@ describe('base coverage', () => {
         assert.equal(c1.bT[0][1], 2);
     });
 
-    it('merges another file coverage with different starting indices', () => {
-        const loc = function(sl, sc, el, ec) {
-            return {
-                start: { line: sl, column: sc },
-                end: { line: el, column: ec }
-            };
-        };
-        const template1 = new FileCoverage({
-            path: '/path/to/file',
-            statementMap: {
-                0: loc(1, 1, 1, 100),
-                1: loc(2, 1, 2, 50),
-                2: loc(2, 51, 2, 100),
-                3: loc(2, 101, 3, 100)
-            },
-            fnMap: {
-                0: {
-                    name: 'foobar',
-                    line: 1,
-                    loc: loc(1, 1, 1, 50)
-                }
-            },
-            branchMap: {
-                0: {
-                    type: 'if',
-                    line: 2,
-                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
-                }
-            },
-            s: {
-                0: 0,
-                1: 0,
-                2: 0,
-                3: 0
-            },
-            f: {
-                0: 0
-            },
-            b: {
-                0: [0, 0]
-            },
-            bT: {
-                0: [0, 0]
-            }
-        });
-        const template2 = new FileCoverage({
-            path: '/path/to/file',
-            statementMap: {
-                1: loc(1, 1, 1, 100),
-                2: loc(2, 1, 2, 50),
-                3: loc(2, 51, 2, 100),
-                4: loc(2, 101, 3, 100)
-            },
-            fnMap: {
-                1: {
-                    name: 'foobar',
-                    line: 1,
-                    loc: loc(1, 1, 1, 50)
-                }
-            },
-            branchMap: {
-                1: {
-                    type: 'if',
-                    line: 2,
-                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
-                }
-            },
-            s: {
-                1: 0,
-                2: 0,
-                3: 0,
-                4: 0
-            },
-            f: {
-                1: 0
-            },
-            b: {
-                1: [0, 0]
-            },
-            bT: {
-                1: [0, 0]
-            }
-        });
-        const clone = function(obj) {
-            return JSON.parse(JSON.stringify(obj));
-        };
-        const c1 = new FileCoverage(clone(template1));
-        const c2 = new FileCoverage(clone(template2));
-        let summary;
-
-        c1.s[0] = 1;
-        c1.f[0] = 1;
-        c1.b[0][0] = 1;
-
-        c2.s[2] = 1;
-        c2.f[1] = 1;
-        c2.b[1][1] = 2;
-        summary = c1.toSummary();
-        assert.ok(summary instanceof CoverageSummary);
-        assert.deepEqual(summary.statements, {
-            total: 4,
-            covered: 1,
-            skipped: 0,
-            pct: 25
-        });
-        assert.deepEqual(summary.lines, {
-            total: 2,
-            covered: 1,
-            skipped: 0,
-            pct: 50
-        });
-        assert.deepEqual(summary.functions, {
-            total: 1,
-            covered: 1,
-            skipped: 0,
-            pct: 100
-        });
-        assert.deepEqual(summary.branches, {
-            total: 2,
-            covered: 1,
-            skipped: 0,
-            pct: 50
-        });
-
-        c1.merge(c2);
-        summary = c1.toSummary();
-        assert.deepEqual(summary.statements, {
-            total: 4,
-            covered: 2,
-            skipped: 0,
-            pct: 50
-        });
-        assert.deepEqual(summary.lines, {
-            total: 2,
-            covered: 2,
-            skipped: 0,
-            pct: 100
-        });
-        assert.deepEqual(summary.functions, {
-            total: 1,
-            covered: 1,
-            skipped: 0,
-            pct: 100
-        });
-        assert.deepEqual(summary.branches, {
-            total: 2,
-            covered: 2,
-            skipped: 0,
-            pct: 100
-        });
-
-        assert.equal(c1.s[0], 1);
-        assert.equal(c1.s[1], 1);
-        assert.equal(c1.f[0], 2);
-        assert.equal(c1.b[0][0], 1);
-        assert.equal(c1.b[0][1], 2);
-    });
-
-    it('drops all data during merges', () => {
-        const loc = function(sl, sc, el, ec) {
-            return {
-                start: { line: sl, column: sc },
-                end: { line: el, column: ec }
-            };
-        };
-        const template = new FileCoverage({
-            path: '/path/to/file',
-            statementMap: {
-                1: loc(1, 1, 1, 100),
-                2: loc(2, 1, 2, 50),
-                3: loc(2, 51, 2, 100),
-                4: loc(2, 101, 3, 100)
-            },
-            fnMap: {
-                1: {
-                    name: 'foobar',
-                    line: 1,
-                    loc: loc(1, 1, 1, 50)
-                }
-            },
-            branchMap: {
-                1: {
-                    type: 'if',
-                    line: 2,
-                    locations: [loc(2, 1, 2, 20), loc(2, 50, 2, 100)]
-                }
-            },
-            s: {
-                1: 0,
-                2: 0,
-                3: 0,
-                4: 0
-            },
-            f: {
-                1: 0
-            },
-            b: {
-                1: [0, 0]
-            },
-            bT: {
-                1: [0, 0]
-            }
-        });
-        const clone = function(obj) {
-            return JSON.parse(JSON.stringify(obj));
-        };
-        const createCoverage = all => {
-            const data = clone(template);
-            if (all) {
-                data.all = true;
-            } else {
-                data.s[1] = 1;
-                data.f[1] = 1;
-                data.b[1][0] = 1;
-                data.bT[1][0] = 1;
-            }
-
-            return new FileCoverage(data);
-        };
-
-        const expected = createCoverage().data;
-        // Get non-all data regardless of merge order
-        let cov = createCoverage(true);
-        cov.merge(createCoverage());
-        assert.deepEqual(cov.data, expected);
-
-        cov = createCoverage();
-        cov.merge(createCoverage(true));
-        assert.deepEqual(cov.data, expected);
-    });
-
     it('resets hits when requested', () => {
         const loc = function(sl, sc, el, ec) {
             return {
@@ -577,7 +682,6 @@ describe('base coverage', () => {
             branchMap: {},
             s: { 1: 0, 2: 1, 3: 0 },
             b: {},
-            bT: {},
             f: {}
         });
         assert.deepEqual(['2'], c.getUncoveredLines());
@@ -594,10 +698,6 @@ describe('base coverage', () => {
             statementMap: {},
             s: {},
             b: {
-                1: [1, 0],
-                2: [0, 0, 0, 1]
-            },
-            bT: {
                 1: [1, 0],
                 2: [0, 0, 0, 1]
             },
@@ -638,10 +738,6 @@ describe('base coverage', () => {
             statementMap: {},
             s: {},
             b: {
-                1: [1, 0],
-                2: [0, 0, 0, 1]
-            },
-            bT: {
                 1: [1, 0],
                 2: [0, 0, 0, 1]
             },


### PR DESCRIPTION
@bcoe 
This are the istanbul-lib-coverage changes to do with evaluating logical expression truthiness.
Blocking the [original pull request ](https://github.com/istanbuljs/istanbuljs/pull/629) until the version is published.

All tests pass.