### PR TITLE
fix(magic-value): make incrementing magic value a manual step

### DIFF
--- a/packages/istanbul-lib-instrument/src/constants.js
+++ b/packages/istanbul-lib-instrument/src/constants.js
@@ -1,12 +1,14 @@
 const { createHash } = require('crypto');
-const { major } = require('semver');
-const { name, version } = require('../package.json');
+const { name } = require('../package.json');
+// TODO: increment this version if there are schema changes
+// that are not backwards compatible:
+const VERSION = '4';
 
 const SHA = 'sha1';
 module.exports = {
     SHA,
     MAGIC_KEY: '_coverageSchema',
     MAGIC_VALUE: createHash(SHA)
-        .update(name + '@' + major(version))
+        .update(name + '@' + VERSION)
         .digest('hex')
 };


### PR DESCRIPTION
We should not change the hash used to identify coverage reports unless
an incompatible change is actually introduced. In practice, we should
try to make sure changes are backwards compatible.

Fixes #631