### PR TITLE
feat: allow FileCoverage to be initialized with logical tracking

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -9,8 +9,8 @@ const dataProperties = require('./data-properties');
 const { CoverageSummary } = require('./coverage-summary');
 
 // returns a data object that represents empty coverage
-function emptyCoverage(filePath) {
-    return {
+function emptyCoverage(filePath, reportLogic) {
+    const cov = {
         path: filePath,
         statementMap: {},
         fnMap: {},
@@ -19,6 +19,8 @@ function emptyCoverage(filePath) {
         f: {},
         b: {}
     };
+    if (reportLogic) cov.bT = {};
+    return cov;
 }
 
 // asserts that a data object "looks like" a coverage object
@@ -99,14 +101,14 @@ class FileCoverage {
      * and empty coverage object with the specified file path or a data object that
      * has all the required properties for a file coverage object.
      */
-    constructor(pathOrObj) {
+    constructor(pathOrObj, reportLogic = false) {
         if (!pathOrObj) {
             throw new Error(
                 'Coverage must be initialized with a path or an object'
             );
         }
         if (typeof pathOrObj === 'string') {
-            this.data = emptyCoverage(pathOrObj);
+            this.data = emptyCoverage(pathOrObj, reportLogic);
         } else if (pathOrObj instanceof FileCoverage) {
             this.data = pathOrObj.data;
         } else if (typeof pathOrObj === 'object') {

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -760,4 +760,11 @@ describe('base coverage', () => {
             bcby
         );
     });
+
+    it('allows file coverage to be initialized with tracking for logical truthiness', () => {
+        let fcov = new FileCoverage('foo.json');
+        assert.notOk(fcov.data.bT);
+        fcov = new FileCoverage('foo.json', true);
+        assert.ok(fcov.data.bT);
+    });
 });


### PR DESCRIPTION
@adrian-burlacu-software otherwise `bt` will be undefined in instrumenter:

Refs #629 
