### PR TITLE
Add statements metric as default on html-spa reporter

### DIFF
--- a/packages/istanbul-reports/lib/html-spa/index.js
+++ b/packages/istanbul-reports/lib/html-spa/index.js
@@ -55,6 +55,7 @@ class HtmlSpaReport extends ReportBase {
         };
 
         this.metricsToShow = opts.metricsToShow || [
+            'statements',
             'lines',
             'branches',
             'functions'


### PR DESCRIPTION
I propose changing the default option to make it more consistent with other reporters.