### PR TITLE
chore: remove unused variable

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -242,7 +242,7 @@ class FileCoverage {
         // Tracking additional information about branch truthiness
         // can be optionally enabled:
         if (this.bT && other.bT) {
-            [hits, map] = mergeProp(
+            [hits] = mergeProp(
                 this.bT,
                 this.branchMap,
                 other.bT,


### PR DESCRIPTION
Not sure if this was supposed to be used and it's not, but currently, it seems to be unused...