### PR TITLE
Convert file url to path

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/pathutils.js
+++ b/packages/istanbul-lib-source-maps/lib/pathutils.js
@@ -5,15 +5,18 @@
 'use strict';
 
 const path = require('path');
+const url = require('url');
 
 module.exports = {
     isAbsolute: path.isAbsolute,
     asAbsolute(file, baseDir) {
+        file = url.fileURLToPath(file)
         return path.isAbsolute(file)
             ? file
             : path.resolve(baseDir || process.cwd(), file);
     },
     relativeTo(file, origFile) {
+        file = url.fileURLToPath(file)
         return path.isAbsolute(file)
             ? file
             : path.resolve(path.dirname(origFile), file);


### PR DESCRIPTION
fix this bug: https://github.com/istanbuljs/nyc/issues/1473
It looks like typescript generated a source map with file urls instead the file paths.

The url.fileURLToPath function will work in Node >= v10.12.0
https://nodejs.org/api/url.html#urlfileurltopathurl