### PR TITLE
docs: add missing `coverageGlobalScope` to instumenter API

### DIFF
--- a/packages/istanbul-lib-instrument/api.md
+++ b/packages/istanbul-lib-instrument/api.md
@@ -47,6 +47,8 @@ instead.
             is found in the original code. This function is called with the source file name and the source map URL. (optional, default `null`)
     -   `opts.debug` **[boolean][15]** turn debugging on. (optional, default `false`)
     -   `opts.parserPlugins` **[array][16]?** set babel parser plugins, see @istanbuljs/schema for defaults.
+    -   `opts.coverageGlobalScope` **[string][14]** the global coverage variable scope. (optional, default `this`)
+    -   `opts.coverageGlobalScopeFunc` **[boolean][15]** use an evaluated function to find coverageGlobalScope. (optional, default `true`)
 
 ### instrumentSync
 

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -25,6 +25,8 @@ const readInitialCoverage = require('./read-coverage');
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on.
  * @param {array} [opts.parserPlugins] - set babel parser plugins, see @istanbuljs/schema for defaults.
+ * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
+ * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
  */
 class Instrumenter {
     constructor(opts = {}) {


### PR DESCRIPTION
When studying [`vite-plugin-istanbul`](https://github.com/iFaxity/vite-plugin-istanbul) and comparing it to [istanbul-lib-instrument/api.md](https://github.com/istanbuljs/istanbuljs/blob/master/packages/istanbul-lib-instrument/api.md), I saw that [it is passing `coverageGlobalScope` and `coverageGlobalScopeFunc` to `createInstrumenter`](https://github.com/iFaxity/vite-plugin-istanbul/blob/5265ed28068e8cff2b40dc51c1fe281fdaab381a/src/index.ts#L66-L68). 
The API docs do not mention these on instrumenter options. These are only mentioned on Program visitor API. 

Instrumenter is passing these to visitor through its options:

https://github.com/istanbuljs/istanbuljs/blob/7cea3b1b8916499398538be32aacf7c1181ef379/packages/istanbul-lib-instrument/src/instrumenter.js#L29-L34

https://github.com/istanbuljs/istanbuljs/blob/7cea3b1b8916499398538be32aacf7c1181ef379/packages/istanbul-lib-instrument/src/instrumenter.js#L78-L80