### PR TITLE
[feature](istanbul-lib-instrument): update ignore regex for "legal" comments

### DIFF
--- a/packages/istanbul-lib-instrument/src/visitor.js
+++ b/packages/istanbul-lib-instrument/src/visitor.js
@@ -5,9 +5,9 @@ const { SourceCoverage } = require('./source-coverage');
 const { SHA, MAGIC_KEY, MAGIC_VALUE } = require('./constants');
 
 // pattern for istanbul to ignore a section
-const COMMENT_RE = /^\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/;
+const COMMENT_RE = /^!?\s*istanbul\s+ignore\s+(if|else|next)(?=\W|$)/;
 // pattern for istanbul to ignore the whole file
-const COMMENT_FILE_RE = /^\s*istanbul\s+ignore\s+(file)(?=\W|$)/;
+const COMMENT_FILE_RE = /^!?\s*istanbul\s+ignore\s+(file)(?=\W|$)/;
 // source map URL pattern
 const SOURCE_MAP_RE = /[#@]\s*sourceMappingURL=(.*)\s*$/m;
 

--- a/packages/istanbul-lib-instrument/test/specs/if-hints.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/if-hints.yaml
@@ -27,6 +27,20 @@ tests:
     statements: {'0': 1, '1': 1 }
 
 ---
+name: ignore if legal
+code: |
+  output = -1;
+  /*! istanbul ignore if */
+  if (args[0] > args [1])
+     output = args[0];
+tests:
+  - args: [10, 20]
+    out: -1
+    lines: {'1': 1, '3': 1 }
+    branches: {'0': [1]}
+    statements: {'0': 1, '1': 1 }
+
+---
 name: ignore else with if block
 code: |
   output = -1;

--- a/packages/istanbul-lib-instrument/test/specs/ignore-legal.yaml
+++ b/packages/istanbul-lib-instrument/test/specs/ignore-legal.yaml
@@ -1,0 +1,9 @@
+---
+name: ignore file legal comment
+code: |
+  /*! istanbul ignore file */
+  output = true === true ? "works" : "doesn't work"
+opts:
+  noCoverage: true
+tests:
+  - name: file is ignored


### PR DESCRIPTION
Resolves #658.

This PR adds support for what `esbuild` calls "legal comments" (https://esbuild.github.io/api/#legal-comments).

The issue being that `esbuild` strips comments when building, so any `/* istanbul ignore (if | else | next) */` comments are ignored when using it (I recently ran into this exact issue trying to get test coverage with a `vite` project). However, `esbuild` will leave "legal" comments in (ie, if the comment starts with `/*!` or `//!`).

## Caveats
According to the above-linked section in `esbuild`'s docs, this only applies to "statement-level" "legal" comments:

> Note that "statement-level" for JS and "rule-level" for CSS means the comment must appear in a context where multiple statements or rules are allowed such as in the top-level scope or in a statement or rule block. So comments inside expressions or at the declaration level are not considered license comments.

I interpret this to mean that the following example might not work:
```js
const fooOrBar = baz ? 'foo' : /*! istanbul ignore next */ 'bar'; 
```

However, I don't believe there is anything `istanbul` can do to solve this, so I'm only noting it here for completeness.

## Documentation (?)
Should we document this somewhere, since `esbuild` is becoming a pretty popular tool and this issue may start to come up more often? I think a footnote in `istanbul/nyc`'s `README` would probably be enough?

## Side Note

I also discovered that there is inconsistent handling of RegEx matching between `/* istanbul ignore (if | else | next) */` and `/* istanbul ignore file */`.

When the `if | else I next` RegEx is tested, it uses `v.match(COMMENT_RE)`. But when `file` is tested, it uses `COMMENT_FILE_RE.test(c.value)`, which is less strict (I altered one of the tests so the comment read `/* plz istanbul ignore file */` and it still passed). I don't know if this is intentional or not, but I noticed it while implementing this and thought I'd bring it up in case it was an oversight.


Thanks for this rad library! Let me know if there is anything else I can do!