### PR TITLE
fix: wrong output `truecount` and `falsecount` of clover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 lerna-debug.log
 packages/*/yarn.lock
 packages/nyc/
+.vscode/*


### PR DESCRIPTION
close #695 

# Changes

- fix wrong `truecount` and `falsecount` in clover
- `switch` will be considered a statement now because it has no binary result (not applicable to `truecount` and `falsecount`).