### PR TITLE
fix: `istanbul-lib-source-maps` to preserve implicit `else` when sourcemaps are used

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -82,6 +82,18 @@ class SourceMapTransformer {
                     locs.push(mapping.loc);
                     mappedHits.push(hits[i]);
                 }
+                // Check if this is an implicit else
+                else if (
+                    branchMeta.type === 'if' &&
+                    i > 0 &&
+                    loc.start.line === undefined &&
+                    loc.start.end === undefined &&
+                    loc.end.line === undefined &&
+                    loc.end.end === undefined
+                ) {
+                    locs.push(loc);
+                    mappedHits.push(hits[i]);
+                }
             });
 
             const locMapping = branchMeta.loc

--- a/packages/istanbul-lib-source-maps/test/testdata/ifWithImplicitElseCoverageData.json
+++ b/packages/istanbul-lib-source-maps/test/testdata/ifWithImplicitElseCoverageData.json
@@ -1,0 +1,104 @@
+{
+    "path": "/path/to/file.js",
+    "statementMap": {
+        "0": {
+            "start": {
+                "line": 2,
+                "column": 2
+            },
+            "end": {
+                "line": 4,
+                "column": 3
+            }
+        },
+        "1": {
+            "start": {
+                "line": 3,
+                "column": 4
+            },
+            "end": {
+                "line": 3,
+                "column": 13
+            }
+        },
+        "2": {
+            "start": {
+                "line": 6,
+                "column": 0
+            },
+            "end": {
+                "line": 6,
+                "column": 10
+            }
+        }
+    },
+    "fnMap": {
+        "0": {
+            "name": "add",
+            "decl": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 5,
+                    "column": 1
+                }
+            },
+            "line": 1
+        }
+    },
+    "branchMap": {
+        "0": {
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 4,
+                    "column": 3
+                }
+            },
+            "type": "if",
+            "locations": [
+                {
+                    "start": {
+                        "line": 2,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 3
+                    }
+                },
+                {
+                    "start": {},
+                    "end": {}
+                }
+            ],
+            "line": 2
+        }
+    },
+    "s": {
+        "0": 1,
+        "1": 0,
+        "2": 1
+    },
+    "f": {
+        "0": 1
+    },
+    "b": {
+        "0": [0, 1]
+    }
+}

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -140,4 +140,51 @@ describe('transformer', () => {
             switchBranchCoverageDataExpectedResult
         );
     });
+
+    it('correctly maps branch count of implicit else', async () => {
+        const implicitElseCoverageData = require('./testdata/ifWithImplicitElseCoverageData.json');
+        const sourceMap = {
+            version: 3,
+            sources: [sourceFileSlash],
+            mappings:
+                'AACA,SAAS,IAAI,GAAW,GAAmB;AAGvC,UAAQ,IAAI,aAAa;AAEzB,MAAG,MAAM,IAAI;AACT,WAAO;AAAA,EACX;AACJ;AAEA,IAAI,GAAG,CAAC;'
+        };
+
+        const coverageMap = createMap({});
+        coverageMap.addFileCoverage(implicitElseCoverageData);
+
+        const transformer = new SourceMapTransformer(
+            () => new TraceMap(sourceMap)
+        );
+
+        const mapped = await transformer.transform(coverageMap);
+        const fileCoverage = mapped.fileCoverageFor(sourceFileSlash);
+
+        assert.deepEqual(fileCoverage.data.b, {
+            '0': [0, 1]
+        });
+
+        assert.deepEqual(fileCoverage.data.branchMap['0'].locations, [
+            {
+                start: {
+                    line: 5,
+                    column: 4
+                },
+                end: {
+                    line: 8,
+                    column: 15
+                }
+            },
+            {
+                start: {
+                    line: undefined,
+                    column: undefined
+                },
+                end: {
+                    line: undefined,
+                    column: undefined
+                }
+            }
+        ]);
+    });
 });


### PR DESCRIPTION
- Fixes #705 

Tested the fix with reproduction case from downstream (https://github.com/vitest-dev/vitest/issues/2239) by modifying `./node_modules/istanbul-lib-source-maps/lib/transformer.js` on the fly. 


```
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |       50 |     100 |     100 |                   
 cov.js   |     100 |       50 |     100 |     100 | 2                 
----------|---------|----------|---------|---------|-------------------

```