### PR TITLE
refactor(istanbul-reports): remove unused `projectRoot` option from clover

### DIFF
--- a/packages/istanbul-reports/lib/clover/index.js
+++ b/packages/istanbul-reports/lib/clover/index.js
@@ -11,7 +11,6 @@ class CloverReport extends ReportBase {
 
         this.cw = null;
         this.xml = null;
-        this.projectRoot = opts.projectRoot || process.cwd();
         this.file = opts.file || 'clover.xml';
     }
 


### PR DESCRIPTION
The `projectRoot` option is not used by Clover reporter. 

The Clover schema specifies following for the `path` attribute so I guess it has to be full path, instead of relative like `projectRoot` is.

> `@path` - the filesystem-specific original path to the file e.g. c:\path\to\Bar.groovy

https://bitbucket.org/atlassian/clover/src/master/etc/schema/clover.xsd