### PR TITLE
Fix istanbul-lib-coverage merge when two branch statements have the same first location

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -217,7 +217,7 @@ class FileCoverage {
         this.data.statementMap = map;
 
         const keyFromLocProp = x => keyFromLoc(x.loc);
-        const keyFromLocationsProp = x => keyFromLoc(x.locations[0]);
+        const keyFromLocationsProp = x => x.locations.map(keyFromLoc).join(';');
 
         [hits, map] = mergeProp(
             this.f,


### PR DESCRIPTION
Hello! We are experiencing an issue using merge when our coverage's branch map contains the same first location. Take for example this code:

```ts
	public isInAsyncSlideEditMode (): boolean {
		return this.playerSync?.isCaptureMode() &&
			this.sourceMedia &&
			this.sourceMedia.isDocument() &&
			!this.activity.isLiveSessionEnabled() &&
			this.activity.isSlidesEnabled();
	};
```

This generated this branch map:
```json
"branchMap": {
	"0": {
		"loc": {
			"start": {
				"line": 59,
				"column": 9
			},
			"end": {
				"line": 59,
				"column": null
			}
		},
		"type": "binary-expr",
		"locations": [
			{
				"start": {
					"line": 59,
					"column": 9
				},
				"end": {
					"line": 59,
					"column": null
				}
			},
			{
				"start": {
					"line": 60,
					"column": 3
				},
				"end": {
					"line": 60,
					"column": null
				}
			},
			{
				"start": {
					"line": 61,
					"column": 3
				},
				"end": {
					"line": 61,
					"column": null
				}
			},
			{
				"start": {
					"line": 62,
					"column": 3
				},
				"end": {
					"line": 62,
					"column": null
				}
			},
			{
				"start": {
					"line": 63,
					"column": 3
				},
				"end": {
					"line": 63,
					"column": null
				}
			}
		]
	},
	"1": {
		"loc": {
			"start": {
				"line": 59,
				"column": 24
			},
			"end": {
				"line": 59,
				"column": null
			}
		},
		"type": "cond-expr",
		"locations": [
			{
				"start": {
					"line": 59,
					"column": 24
				},
				"end": {
					"line": 59,
					"column": null
				}
			},
			{
				"start": {
					"line": 59,
					"column": 24
				},
				"end": {
					"line": 59,
					"column": null
				}
			}
		]
	},
	"2": {
		"loc": {
			"start": {
				"line": 59,
				"column": 9
			},
			"end": {
				"line": 59,
				"column": null
			}
		},
		"type": "binary-expr",
		"locations": [
			{
				"start": {
					"line": 59,
					"column": 9
				},
				"end": {
					"line": 59,
					"column": null
				}
			},
			{
				"start": {
					"line": 59,
					"column": 24
				},
				"end": {
					"line": 59,
					"column": null
				}
			}
		]
	},
	"3": {
		"loc": {
			"start": {
				"line": 67,
				"column": 10
			},
			"end": {
				"line": 67,
				"column": 26
			}
		},
		"type": "binary-expr",
		"locations": [
			{
				"start": {
					"line": 67,
					"column": 10
				},
				"end": {
					"line": 67,
					"column": 26
				}
			},
			{
				"start": {
					"line": 67,
					"column": 26
				},
				"end": {
					"line": 67,
					"column": null
				}
			}
		]
	}
}
```

Note that `branchMap[0].locations[0]` is the exact same as `branchMap[2].locations[0]`. During merge it uses `location[0]` to generate the key to uniquely identify each branch, but these two have the same key. The result is the merge losing 2 branch, so instead of a total 11, it's a total of 9. Additionally depending on the order of the merge, we get a total number of coverage branches to be randomly 6 or 9.

This change makes the key from the entire location object, so these two branches are now considered different and are not munged together during merge.

Thanks!