### PR TITLE
fix(clover): always close last open tag

### DIFF
--- a/packages/istanbul-reports/lib/clover/index.js
+++ b/packages/istanbul-reports/lib/clover/index.js
@@ -113,7 +113,7 @@ class CloverReport extends ReportBase {
         if (node.isRoot()) {
             return;
         }
-        this.xml.closeTag('package');
+        this.xml.closeTag(this.xml.stack[this.xml.stack.length - 1]);
     }
 
     onDetail(node) {


### PR DESCRIPTION
- update the clover reporter to close whatever tag is left open from before, rather than the explicit `package` tag. 

Close #715 
