### PR TITLE
fix: upgrade make-dir to ^4.0.0

### DIFF
--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",
-    "make-dir": "^3.0.0",
+    "make-dir": "^4.0.0",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #725 

https://github.com/sindresorhus/make-dir/releases/tag/v4.0.0

Breaking change includes "Requires node 10 or greater" which is true already of istanbul-lib-report