### PR TITLE
fix(deps): update semver to address CVE-2022-25883

### DIFF
--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -15,7 +15,7 @@
     "@babel/parser": "^7.14.7",
     "@istanbuljs/schema": "^0.1.2",
     "istanbul-lib-coverage": "^3.2.0",
-    "semver": "^6.3.0"
+    "semver": "^7.5.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",

--- a/packages/istanbul-lib-report/package.json
+++ b/packages/istanbul-lib-report/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "istanbul-lib-coverage": "^3.0.0",
-    "make-dir": "^3.0.0",
+    "make-dir": "^4.0.0",
     "supports-color": "^7.1.0"
   },
   "devDependencies": {

--- a/packages/nyc-config-hook-run-in-this-context/package.json
+++ b/packages/nyc-config-hook-run-in-this-context/package.json
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "dependencies": {
-    "semver": "^6.3.0"
+    "semver": "^7.5.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
To fix the [security vulnerability](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) of `semver` `v6.x`. Related to #727.