### PR TITLE
fix(deps)!: upgrade semver CVE-2022-25883

### DIFF
--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -15,7 +15,7 @@
     "@babel/parser": "^7.14.7",
     "@istanbuljs/schema": "^0.1.2",
     "istanbul-lib-coverage": "^3.2.0",
-    "semver": "^6.3.0"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",
@@ -45,6 +45,6 @@
     "instrumentation"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }

--- a/packages/nyc-config-hook-run-in-this-context/package.json
+++ b/packages/nyc-config-hook-run-in-this-context/package.json
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "dependencies": {
-    "semver": "^6.3.0"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -39,6 +39,6 @@
     "nyc": "^15.0.0-beta.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: minimum Node version bumped to 10.