### PR TITLE
fix(ux): address bug with firefox event handling

### DIFF
--- a/packages/istanbul-reports/lib/html/index.js
+++ b/packages/istanbul-reports/lib/html/index.js
@@ -86,7 +86,7 @@ ${htmlHead(details)}
         <template id="filterTemplate">
             <div class="quiet">
                 Filter:
-                <input oninput="onInput()" type="search" id="fileSearch">
+                <input type="search" id="fileSearch">
             </div>
         </template>
     </div>


### PR DESCRIPTION
Fixes #730.

Best practices [discourage the use of inline event handlers](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#inline_event_handlers_%E2%80%94_dont_use_these), but beyond this it seems to cause an issue specific to Firefox's event handling mechanism.

In the current filtering code, two were events are added, one [in the setup function](https://github.com/istanbuljs/istanbuljs/commit/eab47f76be90343f679ef0e5567a21447a4995dc#diff-f32bbb8e6d8d5c271ebc689ab16169ef747e77fb80184746d7337a4827e5a94eR47) and the other [in the inline HTML](https://github.com/istanbuljs/istanbuljs/commit/eab47f76be90343f679ef0e5567a21447a4995dc#diff-f32bbb8e6d8d5c271ebc689ab16169ef747e77fb80184746d7337a4827e5a94eR47). The former is the actual desired filtering function, and the latter looks like a typo, since no `onInput` function actually exists (neither within the scope nor in the project).

This small change allows filtering to work properly in Firefox, and has no adverse effect in Chromium, which seems to silently discard failed calls to non-existent event handlers.