### PR TITLE
[Security] [Dependency] Updated @babel/* packages to fix @babel/traverse critical vulnerability

### DIFF
--- a/packages/istanbul-lib-instrument/package.json
+++ b/packages/istanbul-lib-instrument/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-instrument",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Core istanbul API for JS code coverage",
   "author": "Krishnan Anantheswaran <kananthmail-github@yahoo.com>",
   "main": "src/index.js",
@@ -11,14 +11,14 @@
     "test": "nyc mocha"
   },
   "dependencies": {
-    "@babel/core": "^7.12.3",
-    "@babel/parser": "^7.14.7",
-    "@istanbuljs/schema": "^0.1.2",
+    "@babel/core": "^7.23.9",
+    "@babel/parser": "^7.23.9",
+    "@istanbuljs/schema": "^0.1.3",
     "istanbul-lib-coverage": "^3.2.0",
     "semver": "^7.5.4"
   },
   "devDependencies": {
-    "@babel/cli": "^7.7.5",
+    "@babel/cli": "^7.23.9",
     "chai": "^4.2.0",
     "clone": "^2.1.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
# What is in this PR?

Updated inside **packages/istanbul-lib-instrument**:
- @babel/core from 7.12.3 to 7.23.9
- @babel/parser from 7.14.7 to 7.23.9
- @babel/cli from 7.7.5 to .7.23.9
- @istanbuljs/schema from 0.1.2 to 0.1.3 (optional tbh but updated nonetheless)

# Why?  

The sub dependency @babel/traverse inside @babel/core has a critical vulnerability
https://security.snyk.io/vuln/SNYK-JS-BABELTRAVERSE-5962462

Updated @babel/core which has a more recent version of @babel/traverse to fix this security vulnerability

# Additional Info

While this may or may not effect the end user we do use snyk at work and this was flagged in our dependency tree and I thought i'd be great to push a small update to fix it 🙂.

Let me know if you all have any thoughts please! I'd love to help out in any way possible to get this through along with doing any tasks moving forward in istanbuljs since you all do so much!
