### PR TITLE
chore: update GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16, 18, 20]
+        node: [10, 12, 14, 16, 18, 20, 21]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
@@ -31,9 +31,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: lts/*
       - run: npm install
       - run: npm test
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       paths_released: ${{ steps.manifest_release.outputs.paths_released }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: manifest_release
         with:
           command: manifest
@@ -23,10 +23,10 @@ jobs:
       matrix:
         path: ${{fromJson(needs.release.outputs.paths_released)}}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: lts/*
           registry-url: 'https://external-dot-oss-automation.appspot.com/'
       - name: publish
         env:


### PR DESCRIPTION
We're getting deprecation warnings.

<img width="1705" alt="image" src="https://github.com/istanbuljs/istanbuljs/assets/1404810/b32c33f1-de2b-418b-b4e6-fc586f37b157">

Should also fix the error probably 🤔 