### PR TITLE
chore: maybe fix release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,29 +6,20 @@ name: release-please-submodule
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      paths_released: ${{ steps.manifest_release.outputs.paths_released }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: manifest_release
         with:
-          command: manifest
-          token: ${{ secrets.GITHUB_TOKEN }}
-          default-branch: main
-  publish:
-    runs-on: ubuntu-latest
-    needs: release
-    strategy:
-      fail-fast: false
-      matrix:
-        path: ${{fromJson(needs.release.outputs.paths_released)}}
-    steps:
+          release-type: node
       - uses: actions/checkout@v4
+        if: ${{ steps.manifest_release.outputs.release_created }}
       - uses: actions/setup-node@v4
+        if: ${{ steps.manifest_release.outputs.release_created }}
         with:
           node-version: lts/*
           registry-url: 'https://external-dot-oss-automation.appspot.com/'
       - name: publish
+        if: ${{ steps.manifest_release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_MONOREPO_TOKEN}}
         run: |


### PR DESCRIPTION
Seems #769 broke the automated release somehow

https://github.com/istanbuljs/istanbuljs/actions/runs/8054774858/job/22000625358

<img width="965" alt="image" src="https://github.com/istanbuljs/istanbuljs/assets/1404810/a17661ad-d824-42c5-881f-37ed7b5288f7">

No idea how... Maybe this fixes it? closer to the example in https://github.com/google-github-actions/release-please-action#release-types-supported