### PR TITLE
fix: allow use of importAttributes Babel parser plugin

### DIFF
--- a/packages/istanbul-lib-instrument/api.md
+++ b/packages/istanbul-lib-instrument/api.md
@@ -49,7 +49,7 @@ instead.
     -   `opts.parserPlugins` **[array][16]?** set babel parser plugins, see @istanbuljs/schema for defaults.
     -   `opts.coverageGlobalScope` **[string][14]** the global coverage variable scope. (optional, default `this`)
     -   `opts.coverageGlobalScopeFunc` **[boolean][15]** use an evaluated function to find coverageGlobalScope. (optional, default `true`)
-    -   `opts.generatorOpts` **[array][16]?** set babel generator options
+    -   `opts.generatorOpts` **[Object][13]?** set babel generator options
 
 ### instrumentSync
 

--- a/packages/istanbul-lib-instrument/api.md
+++ b/packages/istanbul-lib-instrument/api.md
@@ -43,12 +43,13 @@ instead.
     -   `opts.autoWrap` **[boolean][15]** set to true to allow `return` statements outside of functions. (optional, default `false`)
     -   `opts.produceSourceMap` **[boolean][15]** set to true to produce a source map for the instrumented code. (optional, default `false`)
     -   `opts.ignoreClassMethods` **[Array][16]** set to array of class method names to ignore for coverage. (optional, default `[]`)
-    -   `opts.sourceMapUrlCallback` **[Function][17]** a callback function that is called when a source map URL.
+    -   `opts.sourceMapUrlCallback` **[Function][17]** a callback function that is called when a source map URL
             is found in the original code. This function is called with the source file name and the source map URL. (optional, default `null`)
     -   `opts.debug` **[boolean][15]** turn debugging on. (optional, default `false`)
     -   `opts.parserPlugins` **[array][16]?** set babel parser plugins, see @istanbuljs/schema for defaults.
     -   `opts.coverageGlobalScope` **[string][14]** the global coverage variable scope. (optional, default `this`)
     -   `opts.coverageGlobalScopeFunc` **[boolean][15]** use an evaluated function to find coverageGlobalScope. (optional, default `true`)
+    -   `opts.generatorOpts` **[array][16]?** set babel generator options
 
 ### instrumentSync
 
@@ -61,9 +62,9 @@ is supported. To instrument ES6 modules, make sure that you set the
 
 -   `code` **[string][14]** the code to instrument
 -   `filename` **[string][14]** the filename against which to track coverage.
--   `inputSourceMap` **[Object][13]?** the source map that maps the not instrumented code back to it's original form.
+-   `inputSourceMap` **[object][13]?** the source map that maps the not instrumented code back to it's original form.
     Is assigned to the coverage object and therefore, is available in the json output and can be used to remap the
-    coverage to the untranspiled source. Must be a plain object.
+    coverage to the untranspiled source.
 
 Returns **[string][14]** the instrumented code.
 
@@ -80,7 +81,7 @@ the callback will be called in the same process tick and is not asynchronous.
 -   `callback` **[Function][17]** the callback
 -   `inputSourceMap` **[Object][13]** the source map that maps the not instrumented code back to it's original form.
     Is assigned to the coverage object and therefore, is available in the json output and can be used to remap the
-    coverage to the untranspiled source. Must be a plain object.
+    coverage to the untranspiled source.
 
 ### lastFileCoverage
 

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -27,6 +27,7 @@ const readInitialCoverage = require('./read-coverage');
  * @param {array} [opts.parserPlugins] - set babel parser plugins, see @istanbuljs/schema for defaults.
  * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
  * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
+ * @param {array} [opts.generatorOpts] - set babel generator options
  */
 class Instrumenter {
     constructor(opts = {}) {
@@ -71,7 +72,7 @@ class Instrumenter {
                 sourceType: opts.esModules ? 'module' : 'script',
                 plugins: opts.parserPlugins
             },
-            generatorOpts: { importAttributesKeyword: 'with' },
+            generatorOpts: opts.generatorOpts,
             plugins: [
                 [
                     ({ types }) => {

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -27,7 +27,7 @@ const readInitialCoverage = require('./read-coverage');
  * @param {array} [opts.parserPlugins] - set babel parser plugins, see @istanbuljs/schema for defaults.
  * @param {string} [opts.coverageGlobalScope=this] the global coverage variable scope.
  * @param {boolean} [opts.coverageGlobalScopeFunc=true] use an evaluated function to find coverageGlobalScope.
- * @param {array} [opts.generatorOpts] - set babel generator options
+ * @param {Object} [opts.generatorOpts] - set babel generator options
  */
 class Instrumenter {
     constructor(opts = {}) {

--- a/packages/istanbul-lib-instrument/src/instrumenter.js
+++ b/packages/istanbul-lib-instrument/src/instrumenter.js
@@ -71,6 +71,7 @@ class Instrumenter {
                 sourceType: opts.esModules ? 'module' : 'script',
                 plugins: opts.parserPlugins
             },
+            generatorOpts: { importAttributesKeyword: 'with' },
             plugins: [
                 [
                     ({ types }) => {

--- a/packages/istanbul-lib-instrument/test/generator-opts.test.js
+++ b/packages/istanbul-lib-instrument/test/generator-opts.test.js
@@ -1,0 +1,49 @@
+/* globals describe, it, context */
+
+const { assert } = require('chai');
+const Instrumenter = require('../src/instrumenter');
+
+const codeWithImportAttribute = `
+  import foo from 'bar' with { type: 'json' };
+`;
+
+const generateCode = (code, parserPlugins, generatorOpts) => {
+    const opts = {
+        esModules: true,
+        produceSourceMap: true,
+        parserPlugins,
+        generatorOpts
+    };
+    const instrumenter = new Instrumenter(opts);
+    return instrumenter.instrumentSync(code, __filename);
+};
+
+describe('generatorOpts', () => {
+    context('when the code has import attributes', () => {
+        context('using "with" importAttributesKeyword', () => {
+            it('should produce configured keyword', () => {
+                const generated = generateCode(
+                    codeWithImportAttribute,
+                    [['importAttributes', { deprecatedAssertSyntax: true }]],
+                    { importAttributesKeyword: 'with' }
+                );
+                assert.ok(generated);
+                assert.ok(typeof generated === 'string');
+                assert.ok(generated.includes("with{type:'json'}"));
+            });
+        });
+
+        context('using "assert" importAttributesKeyword', () => {
+            it('should produce configured keyword', () => {
+                const generated = generateCode(
+                    codeWithImportAttribute,
+                    [['importAttributes', { deprecatedAssertSyntax: true }]],
+                    { importAttributesKeyword: 'assert' }
+                );
+                assert.ok(generated);
+                assert.ok(typeof generated === 'string');
+                assert.ok(generated.includes("assert{type:'json'}"));
+            });
+        });
+    });
+});


### PR DESCRIPTION
`istanbul-lib-instrument` [allows](https://github.com/istanbuljs/istanbuljs/blob/main/packages/istanbul-lib-instrument/api.md#parameters-1) passing a set of Babel parser plugins, but I ran into an error when trying to use Istanbul with [Vitest](https://vitest.dev/) (more context at [this issue](https://github.com/vitest-dev/vitest/issues/5537)) after enabling the `"importAttributes"` plugin added in Babel v7.22.0 ([Babel docs](https://babeljs.io/docs/babel-parser#ecmascript-proposals)):

```
You are using import attributes, without specifying the desired output syntax.
Please specify the "importAttributesKeyword" generator option, whose value can be one of:
 - "with"        : `import { a } from "b" with { type: "json" };`
 - "assert"      : `import { a } from "b" assert { type: "json" };`
 - "with-legacy" : `import { a } from "b" with type: "json";`
```

so this PR just passes that generator option to Babel.