### PR TITLE
fix: `istanbul-lib-source-maps` implicit `else` crash edge case

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/transformer.js
+++ b/packages/istanbul-lib-source-maps/lib/transformer.js
@@ -84,6 +84,7 @@ class SourceMapTransformer {
                 }
                 // Check if this is an implicit else
                 else if (
+                    source &&
                     branchMeta.type === 'if' &&
                     i > 0 &&
                     loc.start.line === undefined &&

--- a/packages/istanbul-lib-source-maps/test/testdata/implicitElseEdgeCase.json
+++ b/packages/istanbul-lib-source-maps/test/testdata/implicitElseEdgeCase.json
@@ -1,0 +1,683 @@
+{
+    "path": "dummyFile.js",
+    "statementMap": {
+        "0": {
+            "start": {
+                "line": 1,
+                "column": 16
+            },
+            "end": {
+                "line": 1,
+                "column": 37
+            }
+        },
+        "1": {
+            "start": {
+                "line": 2,
+                "column": 23
+            },
+            "end": {
+                "line": 2,
+                "column": 54
+            }
+        },
+        "2": {
+            "start": {
+                "line": 3,
+                "column": 22
+            },
+            "end": {
+                "line": 11,
+                "column": 1
+            }
+        },
+        "3": {
+            "start": {
+                "line": 4,
+                "column": 15
+            },
+            "end": {
+                "line": 4,
+                "column": 80
+            }
+        },
+        "4": {
+            "start": {
+                "line": 5,
+                "column": 2
+            },
+            "end": {
+                "line": 7,
+                "column": 85
+            }
+        },
+        "5": {
+            "start": {
+                "line": 5,
+                "column": 15
+            },
+            "end": {
+                "line": 5,
+                "column": 36
+            }
+        },
+        "6": {
+            "start": {
+                "line": 6,
+                "column": 4
+            },
+            "end": {
+                "line": 7,
+                "column": 85
+            }
+        },
+        "7": {
+            "start": {
+                "line": 7,
+                "column": 6
+            },
+            "end": {
+                "line": 7,
+                "column": 85
+            }
+        },
+        "8": {
+            "start": {
+                "line": 8,
+                "column": 2
+            },
+            "end": {
+                "line": 9,
+                "column": 35
+            }
+        },
+        "9": {
+            "start": {
+                "line": 9,
+                "column": 4
+            },
+            "end": {
+                "line": 9,
+                "column": 35
+            }
+        },
+        "10": {
+            "start": {
+                "line": 10,
+                "column": 2
+            },
+            "end": {
+                "line": 10,
+                "column": 16
+            }
+        },
+        "11": {
+            "start": {
+                "line": 12,
+                "column": 22
+            },
+            "end": {
+                "line": 12,
+                "column": 90
+            }
+        },
+        "12": {
+            "start": {
+                "line": 12,
+                "column": 44
+            },
+            "end": {
+                "line": 12,
+                "column": 90
+            }
+        },
+        "13": {
+            "start": {
+                "line": 12,
+                "column": 61
+            },
+            "end": {
+                "line": 12,
+                "column": 90
+            }
+        },
+        "14": {
+            "start": {
+                "line": 15,
+                "column": 4
+            },
+            "end": {
+                "line": 17,
+                "column": 5
+            }
+        },
+        "15": {
+            "start": {
+                "line": 16,
+                "column": 6
+            },
+            "end": {
+                "line": 16,
+                "column": 22
+            }
+        },
+        "16": {
+            "start": {
+                "line": 18,
+                "column": 4
+            },
+            "end": {
+                "line": 20,
+                "column": 5
+            }
+        },
+        "17": {
+            "start": {
+                "line": 19,
+                "column": 6
+            },
+            "end": {
+                "line": 19,
+                "column": 22
+            }
+        },
+        "18": {
+            "start": {
+                "line": 23,
+                "column": 0
+            },
+            "end": {
+                "line": 25,
+                "column": 44
+            }
+        }
+    },
+    "fnMap": {
+        "0": {
+            "name": "(anonymous_0)",
+            "decl": {
+                "start": {
+                    "line": 3,
+                    "column": 22
+                },
+                "end": {
+                    "line": 3,
+                    "column": 23
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 57
+                },
+                "end": {
+                    "line": 11,
+                    "column": 1
+                }
+            },
+            "line": 3
+        },
+        "1": {
+            "name": "(anonymous_1)",
+            "decl": {
+                "start": {
+                    "line": 12,
+                    "column": 22
+                },
+                "end": {
+                    "line": 12,
+                    "column": 23
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 44
+                },
+                "end": {
+                    "line": 12,
+                    "column": 90
+                }
+            },
+            "line": 12
+        },
+        "2": {
+            "name": "(anonymous_2)",
+            "decl": {
+                "start": {
+                    "line": 12,
+                    "column": 44
+                },
+                "end": {
+                    "line": 12,
+                    "column": 45
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 61
+                },
+                "end": {
+                    "line": 12,
+                    "column": 90
+                }
+            },
+            "line": 12
+        },
+        "3": {
+            "name": "(anonymous_3)",
+            "decl": {
+                "start": {
+                    "line": 14,
+                    "column": 2
+                },
+                "end": {
+                    "line": 14,
+                    "column": 3
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 20
+                },
+                "end": {
+                    "line": 21,
+                    "column": 3
+                }
+            },
+            "line": 14
+        },
+        "4": {
+            "name": "SomeDecorator",
+            "decl": {
+                "start": {
+                    "line": 26,
+                    "column": 9
+                },
+                "end": {
+                    "line": 26,
+                    "column": 22
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 26,
+                    "column": 63
+                },
+                "end": {
+                    "line": 27,
+                    "column": 1
+                }
+            },
+            "line": 26
+        },
+        "5": {
+            "name": "noop",
+            "decl": {
+                "start": {
+                    "line": 28,
+                    "column": 9
+                },
+                "end": {
+                    "line": 28,
+                    "column": 13
+                }
+            },
+            "loc": {
+                "start": {
+                    "line": 28,
+                    "column": 24
+                },
+                "end": {
+                    "line": 29,
+                    "column": 1
+                }
+            },
+            "line": 28
+        }
+    },
+    "branchMap": {
+        "0": {
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 15
+                },
+                "end": {
+                    "line": 4,
+                    "column": 80
+                }
+            },
+            "type": "cond-expr",
+            "locations": [
+                {
+                    "start": {
+                        "line": 4,
+                        "column": 26
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 32
+                    }
+                },
+                {
+                    "start": {
+                        "line": 4,
+                        "column": 35
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 80
+                    }
+                }
+            ],
+            "line": 4
+        },
+        "1": {
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 35
+                },
+                "end": {
+                    "line": 4,
+                    "column": 80
+                }
+            },
+            "type": "cond-expr",
+            "locations": [
+                {
+                    "start": {
+                        "line": 4,
+                        "column": 42
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 71
+                    }
+                },
+                {
+                    "start": {
+                        "line": 4,
+                        "column": 74
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 80
+                    }
+                }
+            ],
+            "line": 4
+        },
+        "2": {
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 7,
+                    "column": 85
+                }
+            },
+            "type": "if",
+            "locations": [
+                {
+                    "start": {
+                        "line": 6,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 85
+                    }
+                },
+                {
+                    "start": {},
+                    "end": {}
+                }
+            ],
+            "line": 6
+        },
+        "3": {
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 15
+                },
+                "end": {
+                    "line": 7,
+                    "column": 84
+                }
+            },
+            "type": "binary-expr",
+            "locations": [
+                {
+                    "start": {
+                        "line": 7,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 73
+                    }
+                },
+                {
+                    "start": {
+                        "line": 7,
+                        "column": 78
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 84
+                    }
+                }
+            ],
+            "line": 7
+        },
+        "4": {
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 73
+                }
+            },
+            "type": "cond-expr",
+            "locations": [
+                {
+                    "start": {
+                        "line": 7,
+                        "column": 23
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 53
+                    }
+                },
+                {
+                    "start": {
+                        "line": 7,
+                        "column": 56
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 73
+                    }
+                }
+            ],
+            "line": 7
+        },
+        "5": {
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 2
+                },
+                "end": {
+                    "line": 9,
+                    "column": 35
+                }
+            },
+            "type": "if",
+            "locations": [
+                {
+                    "start": {
+                        "line": 8,
+                        "column": 2
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 35
+                    }
+                },
+                {
+                    "start": {},
+                    "end": {}
+                }
+            ],
+            "line": 8
+        },
+        "6": {
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 6
+                },
+                "end": {
+                    "line": 8,
+                    "column": 20
+                }
+            },
+            "type": "binary-expr",
+            "locations": [
+                {
+                    "start": {
+                        "line": 8,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 10
+                    }
+                },
+                {
+                    "start": {
+                        "line": 8,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 20
+                    }
+                }
+            ],
+            "line": 8
+        },
+        "7": {
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 17,
+                    "column": 5
+                }
+            },
+            "type": "if",
+            "locations": [
+                {
+                    "start": {
+                        "line": 15,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 5
+                    }
+                },
+                {
+                    "start": {},
+                    "end": {}
+                }
+            ],
+            "line": 15
+        },
+        "8": {
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 5
+                }
+            },
+            "type": "if",
+            "locations": [
+                {
+                    "start": {
+                        "line": 18,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 5
+                    }
+                },
+                {
+                    "start": {},
+                    "end": {}
+                }
+            ],
+            "line": 18
+        }
+    },
+    "s": {
+        "0": 0,
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 0,
+        "9": 0,
+        "10": 0,
+        "11": 0,
+        "12": 0,
+        "13": 0,
+        "14": 0,
+        "15": 0,
+        "16": 0,
+        "17": 0,
+        "18": 0
+    },
+    "f": {
+        "0": 0,
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0
+    },
+    "b": {
+        "0": [0, 0],
+        "1": [0, 0],
+        "2": [0, 0],
+        "3": [0, 0],
+        "4": [0, 0],
+        "5": [0, 0],
+        "6": [0, 0],
+        "7": [0, 0],
+        "8": [0, 0]
+    }
+}

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -187,4 +187,24 @@ describe('transformer', () => {
             }
         ]);
     });
+
+    it('implicit else does not crash on edge case (#706)', async () => {
+        const implicitElseCoverageData = require('./testdata/implicitElseEdgeCase.json');
+
+        const sourceMap = {
+            version: 3,
+            sources: [sourceFileSlash],
+            mappings:
+                ';;;;;;;;;;;;AAEO,aAAM,iBAAiB;AAAA,EAC5B,OAAsB,WAAsB;AAC1C,QAAI,WAAW;AAEb,WAAK,SAAS;AAAA,IAChB;AAEA,QAAI,cAAc,aAAa;AAE7B,WAAK,SAAS;AAAA,IAChB;AAAA,EACF;AACF;AAXE;AAAA,EAAQ;AAAA,GADG,iBACX;AAaF,SAAS,cACP,SACA,cACA,iBACA;AAAC;AAIH,SAAS,QAAQ,OAAkB;AAEnC;'
+        };
+
+        const coverageMap = createMap({});
+        coverageMap.addFileCoverage(implicitElseCoverageData);
+
+        const transformer = new SourceMapTransformer(
+            () => new TraceMap(sourceMap)
+        );
+
+        await transformer.transform(coverageMap);
+    });
 });


### PR DESCRIPTION
- Fixes https://github.com/istanbuljs/istanbuljs/pull/706#issuecomment-2200012354

In Vitest codebase the `istanbul-lib-source-maps@5.0.5` caused a crash in edge case. The crash happend when `swc` transpiled code was added to report as uncovered file (`coverage.all`).

We can safely look for `source` before adding implicit `else` into the map. There should always be `source` already set from the previous loop of the `if` itself. 
