### PR TITLE
feat: update HTML report filter to take a RegEx

### DIFF
--- a/packages/istanbul-reports/lib/html/assets/sorter.js
+++ b/packages/istanbul-reports/lib/html/assets/sorter.js
@@ -27,7 +27,7 @@ var addSorting = (function() {
         const searchValue = document.getElementById('fileSearch').value;
         const rows = document.getElementsByTagName('tbody')[0].children;
 
-        // Try to create a RegExp from the searchValue. If it fails (invalid regex), 
+        // Try to create a RegExp from the searchValue. If it fails (invalid regex),
         // it will be treated as a plain text search
         let searchRegex;
         try {

--- a/packages/istanbul-reports/lib/html/assets/sorter.js
+++ b/packages/istanbul-reports/lib/html/assets/sorter.js
@@ -26,17 +26,29 @@ var addSorting = (function() {
     function onFilterInput() {
         const searchValue = document.getElementById('fileSearch').value;
         const rows = document.getElementsByTagName('tbody')[0].children;
+    
+        // Try to create a RegExp from the searchValue. If it fails (invalid regex), 
+        // it will be treated as a plain text search
+        let searchRegex;
+        try {
+            searchRegex = new RegExp(searchValue, 'i'); // 'i' for case-insensitive
+        } catch (error) {
+            searchRegex = null; 
+        }
+    
         for (let i = 0; i < rows.length; i++) {
             const row = rows[i];
-            if (
-                row.textContent
-                    .toLowerCase()
-                    .includes(searchValue.toLowerCase())
-            ) {
-                row.style.display = '';
+            let isMatch = false;
+    
+            if (searchRegex) {
+                // If a valid regex was created, use it for matching
+                isMatch = searchRegex.test(row.textContent);
             } else {
-                row.style.display = 'none';
+                // Otherwise, fall back to the original plain text search
+                isMatch = row.textContent.toLowerCase().includes(searchValue.toLowerCase());
             }
+    
+            row.style.display = isMatch ? '' : 'none';
         }
     }
 

--- a/packages/istanbul-reports/lib/html/assets/sorter.js
+++ b/packages/istanbul-reports/lib/html/assets/sorter.js
@@ -26,28 +26,30 @@ var addSorting = (function() {
     function onFilterInput() {
         const searchValue = document.getElementById('fileSearch').value;
         const rows = document.getElementsByTagName('tbody')[0].children;
-    
+
         // Try to create a RegExp from the searchValue. If it fails (invalid regex), 
         // it will be treated as a plain text search
         let searchRegex;
         try {
             searchRegex = new RegExp(searchValue, 'i'); // 'i' for case-insensitive
         } catch (error) {
-            searchRegex = null; 
+            searchRegex = null;
         }
-    
+
         for (let i = 0; i < rows.length; i++) {
             const row = rows[i];
             let isMatch = false;
-    
+
             if (searchRegex) {
                 // If a valid regex was created, use it for matching
                 isMatch = searchRegex.test(row.textContent);
             } else {
                 // Otherwise, fall back to the original plain text search
-                isMatch = row.textContent.toLowerCase().includes(searchValue.toLowerCase());
+                isMatch = row.textContent
+                    .toLowerCase()
+                    .includes(searchValue.toLowerCase());
             }
-    
+
             row.style.display = isMatch ? '' : 'none';
         }
     }


### PR DESCRIPTION
Building on https://github.com/istanbuljs/istanbuljs/pull/650

Allowing the HTML report filter to take regex syntax. Particularly useful with large reports 😊

![html-report-regex-filter gif](https://github.com/user-attachments/assets/36e35109-995a-46b0-8dd5-f5053540ea2a)
