### PR TITLE
feat(lcov): support absolute paths

### DIFF
--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -30,7 +30,7 @@ class LcovOnlyReport extends ReportBase {
         const path = require('path');
 
         writer.println('TN:');
-        const fileName = path.relative(this.projectRoot, fc.path);
+        const fileName = (this.projectRoot === '/' ? '/' : '') + path.relative(this.projectRoot, fc.path);
         writer.println('SF:' + fileName);
 
         Object.values(functionMap).forEach(meta => {

--- a/packages/istanbul-reports/lib/lcovonly/index.js
+++ b/packages/istanbul-reports/lib/lcovonly/index.js
@@ -30,7 +30,9 @@ class LcovOnlyReport extends ReportBase {
         const path = require('path');
 
         writer.println('TN:');
-        const fileName = (this.projectRoot === '/' ? '/' : '') + path.relative(this.projectRoot, fc.path);
+        const fileName =
+            (this.projectRoot === '/' ? '/' : '') +
+            path.relative(this.projectRoot, fc.path);
         writer.println('SF:' + fileName);
 
         Object.values(functionMap).forEach(meta => {


### PR DESCRIPTION
Closes https://github.com/istanbuljs/istanbuljs/issues/529

There are a handful of discussions about the "correct" path format (see https://github.com/jestjs/jest/issues/9773 as an example), but as implemented, it's not possible to get absolute paths without forking the reporter or post-processing the output.

This is a simple change to output absolute paths when the `projectRoot` is set to `/`.

Happy to make adjustments, but wanted to at least open the PR to start the discussion.