### PR TITLE
fix: The color of 'missing if branch' is incorrect

### DIFF
--- a/packages/istanbul-reports/lib/html/assets/base.css
+++ b/packages/istanbul-reports/lib/html/assets/base.css
@@ -110,7 +110,7 @@ table.coverage td span.cline-any {
     background: #ccc;
     color: white;
 }
-.missing-if-branch .typ, .skip-if-branch .typ {
+.missing-if-branch > span, .skip-if-branch > span {
     color: inherit !important;
 }
 .coverage-summary {


### PR DESCRIPTION
[view case](https://github.com/canyon-project/canyon/tree/main/examples/vanilla-nyc)

![3091729845741_ pic](https://github.com/user-attachments/assets/c7bea384-51a3-4d7f-afb3-8c8dfcde6c81)