### PR TITLE
fix: html-spa table formatting

### DIFF
--- a/packages/istanbul-reports/lib/html-spa/assets/spa.css
+++ b/packages/istanbul-reports/lib/html-spa/assets/spa.css
@@ -212,7 +212,7 @@ a:hover {
 }
 
 .coverage-summary th {
-    text-align: center;
+    text-align: left;
     font-weight: normal;
     white-space: nowrap;
 }
@@ -252,8 +252,8 @@ a:hover {
     color: #666;
 }
 
-.coverage-summary .headercell:nth-child(5n - 2),
-.coverage-summary td:nth-child(5n - 2) {
+.coverage-summary .headercell:nth-child(5n - 3),
+.coverage-summary td:nth-child(5n - 3) {
     border-left: 2px solid #fcfcfc;
     padding-left: 2em;
 }

--- a/packages/istanbul-reports/lib/html-spa/src/summaryTableHeader.js
+++ b/packages/istanbul-reports/lib/html-spa/src/summaryTableHeader.js
@@ -89,10 +89,10 @@ module.exports = function SummaryTableHeader({
         <thead>
             <tr className="topheading">
                 <th></th>
-                {metricsToShow.statements && <th colSpan={4}>Statements</th>}
-                {metricsToShow.branches && <th colSpan={4}>Branches</th>}
-                {metricsToShow.functions && <th colSpan={4}>Functions</th>}
-                {metricsToShow.lines && <th colSpan={4}>Lines</th>}
+                {metricsToShow.statements && <th colSpan={5}>Statements</th>}
+                {metricsToShow.branches && <th colSpan={5}>Branches</th>}
+                {metricsToShow.functions && <th colSpan={5}>Functions</th>}
+                {metricsToShow.lines && <th colSpan={5}>Lines</th>}
             </tr>
             <tr className="subheading">
                 <FileHeaderCell onSort={onSort} activeSort={activeSort} />


### PR DESCRIPTION
This change fixes the table formatting for the html-spa report.

- Changes the column headings to correctly span their respective 5 columns.
- Changes the borders to correctly separate their respective sections
- Align column heading text to left, to make it easier to read.


See screenshots below for the visual before and after of this change.


**Before:**
![before](https://github.com/user-attachments/assets/9be4d949-38cb-46ed-ba1c-23ee906999d7)
**After:**
![after](https://github.com/user-attachments/assets/ab8dd5f1-804a-4a2e-89b1-6393a180054e)
