### PR TITLE
fix: `istanbul-lib-source-maps` to map functions without closing brace mapping

### DIFF
--- a/packages/istanbul-lib-source-maps/lib/get-mapping.js
+++ b/packages/istanbul-lib-source-maps/lib/get-mapping.js
@@ -36,13 +36,27 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
     // generated file end location. Note however that this position on its
     // own is not useful because it is the position of the _start_ of the range
     // on the original file, and we want the _end_ of the range.
-    const beforeEndMapping = originalPositionTryBoth(
+    let beforeEndMapping = originalPositionTryBoth(
         sourceMap,
         generatedEnd.line,
         generatedEnd.column - 1
     );
     if (beforeEndMapping.source === null) {
-        return null;
+        // search the previous lines as the mapping was not found on the same line
+        for (
+            let line = generatedEnd.line;
+            line > 0 && beforeEndMapping.source === null;
+            line--
+        ) {
+            beforeEndMapping = originalPositionTryBoth(
+                sourceMap,
+                line,
+                Number.MAX_SAFE_INTEGER
+            );
+        }
+        if (beforeEndMapping.source === null) {
+            return null;
+        }
     }
 
     // Convert that original position back to a generated one, with a bump

--- a/packages/istanbul-lib-source-maps/lib/get-mapping.js
+++ b/packages/istanbul-lib-source-maps/lib/get-mapping.js
@@ -51,7 +51,7 @@ function originalEndPositionFor(sourceMap, generatedEnd) {
             beforeEndMapping = originalPositionTryBoth(
                 sourceMap,
                 line,
-                Number.MAX_SAFE_INTEGER
+                Infinity
             );
         }
         if (beforeEndMapping.source === null) {

--- a/packages/istanbul-lib-source-maps/test/testdata/functionWithoutClosingBraceCoverageData.json
+++ b/packages/istanbul-lib-source-maps/test/testdata/functionWithoutClosingBraceCoverageData.json
@@ -1,0 +1,49 @@
+{
+    "path": "dummyFile.ts",
+    "statementMap": {
+        "0": {
+            "start": { "line": 2, "column": 1 },
+            "end": { "line": 2, "column": 20 }
+        },
+        "1": {
+            "start": { "line": 5, "column": 1 },
+            "end": { "line": 5, "column": 19 }
+        }
+    },
+    "fnMap": {
+        "0": {
+            "name": "isEven",
+            "decl": {
+                "start": { "line": 1, "column": 16 },
+                "end": { "line": 1, "column": 22 }
+            },
+            "loc": {
+                "start": { "line": 1, "column": 26 },
+                "end": { "line": 3, "column": 1 }
+            },
+            "line": 1
+        },
+        "1": {
+            "name": "isOdd",
+            "decl": {
+                "start": { "line": 4, "column": 16 },
+                "end": { "line": 4, "column": 21 }
+            },
+            "loc": {
+                "start": { "line": 4, "column": 25 },
+                "end": { "line": 6, "column": 1 }
+            },
+            "line": 4
+        }
+    },
+    "branchMap": {},
+    "s": {
+        "0": 1,
+        "1": 0
+    },
+    "f": {
+        "0": 1,
+        "1": 0
+    },
+    "b": {}
+}

--- a/packages/istanbul-lib-source-maps/test/transformer.test.js
+++ b/packages/istanbul-lib-source-maps/test/transformer.test.js
@@ -207,4 +207,53 @@ describe('transformer', () => {
 
         await transformer.transform(coverageMap);
     });
+
+    it('correctly maps function without `}` mapping', async () => {
+        const functionWithoutClosingBraceCoverageData = require('./testdata/functionWithoutClosingBraceCoverageData.json');
+        const sourceMap = {
+            version: 3,
+            sources: [sourceFileSlash],
+            mappings:
+                'AAAA,OAAO,SAAS,OAAO,GAAW;AAChC,QAAO,IAAI,MAAM;;AAGnB,OAAO,SAAS,MAAM,GAAW;AAC/B,QAAO,CAAC,OAAO,EAAE'
+        };
+
+        const coverageMap = createMap({});
+        coverageMap.addFileCoverage(functionWithoutClosingBraceCoverageData);
+
+        const transformer = new SourceMapTransformer(
+            () => new TraceMap(sourceMap)
+        );
+
+        const mapped = await transformer.transform(coverageMap);
+        const fileCoverage = mapped.fileCoverageFor(sourceFileSlash);
+
+        assert.deepEqual(fileCoverage.data.f, {
+            '0': 1,
+            '1': 0
+        });
+
+        assert.deepEqual(fileCoverage.data.fnMap['0'], {
+            name: 'isEven',
+            decl: {
+                start: {
+                    line: 1,
+                    column: 16
+                },
+                end: {
+                    line: 1,
+                    column: 23
+                }
+            },
+            loc: {
+                start: {
+                    line: 1,
+                    column: 34
+                },
+                end: {
+                    line: 2,
+                    column: Infinity
+                }
+            }
+        });
+    });
 });


### PR DESCRIPTION
This PR fixes an issue in `istanbul-lib-source-maps` where functions were not mapped correctly when no closing brace mapping was present.

Oxc does not generate a source map entry for `}` ([sourcemap visualizer](https://evanw.github.io/source-map-visualization/#MTAwAGV4cG9ydCBmdW5jdGlvbiBpc0V2ZW4oYSkgewoJcmV0dXJuIGEgJSAyID09PSAwOwp9CmV4cG9ydCBmdW5jdGlvbiBpc09kZChhKSB7CglyZXR1cm4gIWlzRXZlbihhKTsKfQozMDMAeyJ2ZXJzaW9uIjozLCJuYW1lcyI6W10sInNvdXJjZXMiOlsidGVzdC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGZ1bmN0aW9uIGlzRXZlbihhOiBudW1iZXIpIHtcbiAgcmV0dXJuIGEgJSAyID09PSAwXG59XG5cbmV4cG9ydCBmdW5jdGlvbiBpc09kZChhOiBudW1iZXIpIHtcbiAgcmV0dXJuICFpc0V2ZW4oYSlcbn0iXSwibWFwcGluZ3MiOiJBQUFBLE9BQU8sU0FBUyxPQUFPLEdBQVc7QUFDaEMsUUFBTyxJQUFJLE1BQU07O0FBR25CLE9BQU8sU0FBUyxNQUFNLEdBQVc7QUFDL0IsUUFBTyxDQUFDLE9BQU8sRUFBRSJ9)) because it does not affect the debugger nor stack traces. However, this caused Vitest's coverage feature to behave incorrectly when switching to Oxc (from esbuild). The problem was in the fallback logic that is used when a closing brace mapping does not exist. While it searched for other mappings on the same line, it did not search for mappings on different lines.

Apparently, a similar issue was found in esbuild in the past (https://github.com/evanw/esbuild/issues/1448) and was worked around on the esbuild side (https://github.com/evanw/esbuild/commit/c4d45e6b5766b1a1b56bf24b7dadb240de91332b). This PR would also allow those changes to be reverted.
