### PR TITLE
fix: use lenient matching for coverage merge when end.column differs

### DIFF
--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -45,6 +45,11 @@ function assertValidObject(obj) {
 const keyFromLoc = ({ start, end }) =>
     `${start.line}|${start.column}|${end.line}|${end.column}`;
 
+// Lenient key that ignores end.column - used for fuzzy matching when exact match fails
+// This handles cases where different transpilers produce different end.column values
+const keyFromLocLenient = ({ start, end }) =>
+    `${start.line}|${start.column}|${end.line}`;
+
 const isObj = o => !!o && typeof o === 'object';
 const isLineCol = o =>
     isObj(o) && typeof o.line === 'number' && typeof o.column === 'number';
@@ -131,36 +136,76 @@ const addNearestContainerHits = (item, itemHits, map, mapHits) => {
 };
 
 const mergeProp = (aHits, aMap, bHits, bMap, itemKey = keyFromLoc) => {
-    const aItems = {};
-    for (const [key, itemHits] of Object.entries(aHits)) {
-        const item = aMap[key];
-        aItems[itemKey(item)] = [itemHits, item];
-    }
-    const bItems = {};
-    for (const [key, itemHits] of Object.entries(bHits)) {
-        const item = bMap[key];
-        bItems[itemKey(item)] = [itemHits, item];
-    }
+    // Derive lenient key function from the provided itemKey
+    // Handle both regular items (statements, functions) and branch items (which use locations[0])
+    // Returns null if loc is invalid (e.g., end.column is null)
+    const itemKeyLenient = item => {
+        const loc = item.locations ? getLoc(item.locations[0]) : getLoc(item);
+        return loc ? keyFromLocLenient(loc) : null;
+    };
+
+    // Build items index with both exact and lenient keys for fuzzy matching
+    const buildItemsIndex = (hits, map) => {
+        const items = {};
+        const itemsLenient = {};
+        for (const [key, itemHits] of Object.entries(hits)) {
+            const item = map[key];
+            const exactKey = itemKey(item);
+            items[exactKey] = [itemHits, item];
+            const lenientKey = itemKeyLenient(item);
+            if (lenientKey && !itemsLenient[lenientKey]) {
+                itemsLenient[lenientKey] = exactKey;
+            }
+        }
+        return [items, itemsLenient];
+    };
+
+    const [aItems, aItemsLenient] = buildItemsIndex(aHits, aMap);
+    const [bItems, bItemsLenient] = buildItemsIndex(bHits, bMap);
+
     const mergedItems = {};
+    const matchedBKeys = new Set(); // track which B items have been matched
+
     for (const [key, aValue] of Object.entries(aItems)) {
         let aItemHits = aValue[0];
         const aItem = aValue[1];
-        const bValue = bItems[key];
+        let bValue = bItems[key];
+        let matchedBKey = key;
+
+        // If exact match fails, try lenient match (ignoring end.column)
+        if (!bValue) {
+            const lenientKey = itemKeyLenient(aItem);
+            if (lenientKey) {
+                const bExactKey = bItemsLenient[lenientKey];
+                if (bExactKey && !matchedBKeys.has(bExactKey)) {
+                    bValue = bItems[bExactKey];
+                    matchedBKey = bExactKey;
+                }
+            }
+        }
+
         if (!bValue) {
             // not an identified range in b, but might be contained by one
             aItemHits = addNearestContainerHits(aItem, aItemHits, bMap, bHits);
         } else {
             // is an identified range in b, so add the hits together
             aItemHits = addHits(aItemHits, bValue[0]);
+            matchedBKeys.add(matchedBKey);
         }
         mergedItems[key] = [aItemHits, aItem];
     }
+
     // now find the items in b that are not in a. already added matches.
     for (const [key, bValue] of Object.entries(bItems)) {
         let bItemHits = bValue[0];
         const bItem = bValue[1];
-        if (mergedItems[key]) continue;
-        // not an identified range in b, but might be contained by one
+        if (mergedItems[key] || matchedBKeys.has(key)) continue;
+
+        // Try lenient match - if a lenient match exists in A, skip (already merged)
+        const lenientKey = itemKeyLenient(bItem);
+        if (lenientKey && aItemsLenient[lenientKey]) continue;
+
+        // not an identified range in a, but might be contained by one
         bItemHits = addNearestContainerHits(bItem, bItemHits, aMap, aHits);
         mergedItems[key] = [bItemHits, bItem];
     }

--- a/packages/istanbul-lib-coverage/lib/file-coverage.js
+++ b/packages/istanbul-lib-coverage/lib/file-coverage.js
@@ -47,8 +47,8 @@ const keyFromLoc = ({ start, end }) =>
 
 // Lenient key that ignores end.column - used for fuzzy matching when exact match fails
 // This handles cases where different transpilers produce different end.column values
-const keyFromLocLenient = ({ start, end }) =>
-    `${start.line}|${start.column}|${end.line}`;
+const REMOVE_END_MAPPING_PATTERN = /^([^|]+\|[^|]+\|[^|]+)\|[^|]*$/;
+const keyFromLocLenient = key => key.replace(REMOVE_END_MAPPING_PATTERN, '$1');
 
 const isObj = o => !!o && typeof o === 'object';
 const isLineCol = o =>
@@ -136,14 +136,6 @@ const addNearestContainerHits = (item, itemHits, map, mapHits) => {
 };
 
 const mergeProp = (aHits, aMap, bHits, bMap, itemKey = keyFromLoc) => {
-    // Derive lenient key function from the provided itemKey
-    // Handle both regular items (statements, functions) and branch items (which use locations[0])
-    // Returns null if loc is invalid (e.g., end.column is null)
-    const itemKeyLenient = item => {
-        const loc = item.locations ? getLoc(item.locations[0]) : getLoc(item);
-        return loc ? keyFromLocLenient(loc) : null;
-    };
-
     // Build items index with both exact and lenient keys for fuzzy matching
     const buildItemsIndex = (hits, map) => {
         const items = {};
@@ -152,8 +144,9 @@ const mergeProp = (aHits, aMap, bHits, bMap, itemKey = keyFromLoc) => {
             const item = map[key];
             const exactKey = itemKey(item);
             items[exactKey] = [itemHits, item];
-            const lenientKey = itemKeyLenient(item);
-            if (lenientKey && !itemsLenient[lenientKey]) {
+            // Derive lenient key by stripping end.column from the exact key
+            const lenientKey = keyFromLocLenient(exactKey);
+            if (!itemsLenient[lenientKey]) {
                 itemsLenient[lenientKey] = exactKey;
             }
         }
@@ -174,13 +167,11 @@ const mergeProp = (aHits, aMap, bHits, bMap, itemKey = keyFromLoc) => {
 
         // If exact match fails, try lenient match (ignoring end.column)
         if (!bValue) {
-            const lenientKey = itemKeyLenient(aItem);
-            if (lenientKey) {
-                const bExactKey = bItemsLenient[lenientKey];
-                if (bExactKey && !matchedBKeys.has(bExactKey)) {
-                    bValue = bItems[bExactKey];
-                    matchedBKey = bExactKey;
-                }
+            const lenientKey = keyFromLocLenient(key);
+            const bExactKey = bItemsLenient[lenientKey];
+            if (bExactKey && !matchedBKeys.has(bExactKey)) {
+                bValue = bItems[bExactKey];
+                matchedBKey = bExactKey;
             }
         }
 
@@ -202,8 +193,8 @@ const mergeProp = (aHits, aMap, bHits, bMap, itemKey = keyFromLoc) => {
         if (mergedItems[key] || matchedBKeys.has(key)) continue;
 
         // Try lenient match - if a lenient match exists in A, skip (already merged)
-        const lenientKey = itemKeyLenient(bItem);
-        if (lenientKey && aItemsLenient[lenientKey]) continue;
+        const lenientKey = keyFromLocLenient(key);
+        if (aItemsLenient[lenientKey]) continue;
 
         // not an identified range in a, but might be contained by one
         bItemHits = addNearestContainerHits(bItem, bItemHits, aMap, aHits);

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -1132,19 +1132,17 @@ describe('lenient merge with different end.column values', () => {
                 end: { line: el, column: ec }
             };
         };
-        // Simulate coverage from two different transpilers that produce
-        // different end.column values for the same logical statement
         const c1 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 50), // end.column = 50
+                0: loc(1, 0, 1, 50),
                 1: loc(2, 0, 2, 30)
             },
             fnMap: {
                 0: {
                     name: 'foo',
                     line: 1,
-                    loc: loc(1, 0, 1, 50) // end.column = 50
+                    loc: loc(1, 0, 1, 50)
                 }
             },
             branchMap: {
@@ -1162,21 +1160,21 @@ describe('lenient merge with different end.column values', () => {
         const c2 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 55), // end.column = 55 (different!)
-                1: loc(2, 0, 2, 35) // end.column = 35 (different!)
+                0: loc(1, 0, 1, 55),
+                1: loc(2, 0, 2, 35)
             },
             fnMap: {
                 0: {
                     name: 'foo',
                     line: 1,
-                    loc: loc(1, 0, 1, 55) // end.column = 55 (different!)
+                    loc: loc(1, 0, 1, 55)
                 }
             },
             branchMap: {
                 0: {
                     type: 'if',
                     line: 2,
-                    locations: [loc(2, 0, 2, 35), loc(2, 35, 2, 65)] // different end columns
+                    locations: [loc(2, 0, 2, 35), loc(2, 35, 2, 65)]
                 }
             },
             s: { 0: 0, 1: 1 },
@@ -1187,17 +1185,12 @@ describe('lenient merge with different end.column values', () => {
         c1.merge(c2);
         const summary = c1.toSummary();
 
-        // With lenient matching, both statements should be merged
-        // Statement 0: 1 + 0 = 1 (covered)
-        // Statement 1: 0 + 1 = 1 (covered)
         assert.deepEqual(summary.statements, {
             total: 2,
             covered: 2,
             skipped: 0,
             pct: 100
         });
-
-        // Functions should be merged: 1 + 1 = 2
         assert.deepEqual(summary.functions, {
             total: 1,
             covered: 1,
@@ -1205,8 +1198,6 @@ describe('lenient merge with different end.column values', () => {
             pct: 100
         });
         assert.equal(c1.f[0], 2);
-
-        // Branches should be merged: [1, 0] + [0, 1] = [1, 1]
         assert.deepEqual(summary.branches, {
             total: 2,
             covered: 2,
@@ -1216,8 +1207,6 @@ describe('lenient merge with different end.column values', () => {
     });
 
     it('only stores first A item when multiple A items share same lenient key', () => {
-        // Test coverage for lines 155-157: if (!aItemsLenient[lenientKey])
-        // When A has multiple items with same lenient key, only the first is stored
         const loc = function(sl, sc, el, ec) {
             return {
                 start: { line: sl, column: sc },
@@ -1228,8 +1217,8 @@ describe('lenient merge with different end.column values', () => {
         const c1 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 50), // lenient key: 1|0|1
-                1: loc(1, 0, 1, 60) // lenient key: 1|0|1 (same!) - triggers line 155 false branch
+                0: loc(1, 0, 1, 50),
+                1: loc(1, 0, 1, 60)
             },
             fnMap: {},
             branchMap: {},
@@ -1241,7 +1230,7 @@ describe('lenient merge with different end.column values', () => {
         const c2 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 55) // lenient key: 1|0|1 - matches first A item
+                0: loc(1, 0, 1, 55)
             },
             fnMap: {},
             branchMap: {},
@@ -1252,8 +1241,6 @@ describe('lenient merge with different end.column values', () => {
 
         c1.merge(c2);
 
-        // First A item (index 0) should be merged with B's item: 2 + 4 = 6
-        // Second A item (index 1) keeps its original value: 3
         assert.equal(c1.s[0], 6);
         assert.equal(c1.s[1], 3);
         const summary = c1.toSummary();
@@ -1261,10 +1248,6 @@ describe('lenient merge with different end.column values', () => {
     });
 
     it('skips extra B items that share lenient key with A items', () => {
-        // Test coverage for line 210: if (aItemsLenient[lenientKey]) continue;
-        // When B has multiple items with same lenient key as an A item,
-        // only the first B item gets lenient-matched in the first loop.
-        // The second B item should be skipped in the second loop via line 210.
         const loc = function(sl, sc, el, ec) {
             return {
                 start: { line: sl, column: sc },
@@ -1275,7 +1258,7 @@ describe('lenient merge with different end.column values', () => {
         const c1 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 50) // lenient key: 1|0|1
+                0: loc(1, 0, 1, 50)
             },
             fnMap: {},
             branchMap: {},
@@ -1287,8 +1270,8 @@ describe('lenient merge with different end.column values', () => {
         const c2 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
-                0: loc(1, 0, 1, 99), // lenient key: 1|0|1 (same as c1)
-                1: loc(1, 0, 1, 88) // lenient key: 1|0|1 (same as c1) - this triggers line 210
+                0: loc(1, 0, 1, 99),
+                1: loc(1, 0, 1, 88)
             },
             fnMap: {},
             branchMap: {},
@@ -1299,16 +1282,12 @@ describe('lenient merge with different end.column values', () => {
 
         c1.merge(c2);
 
-        // A's item should be merged with B's first matching item (index 0)
-        // B's second item (index 1) shares same lenient key, should be skipped via line 210
         const summary = c1.toSummary();
-        assert.equal(summary.statements.total, 1); // Only 1 statement, not 2
-        assert.equal(c1.s[0], 8); // 5 + 3 = 8 (B's item 1 with value 7 is skipped)
+        assert.equal(summary.statements.total, 1);
+        assert.equal(c1.s[0], 8);
     });
 
     it('handles null end.column gracefully without crashing', () => {
-        // Test case from Vitest merge-reports: end.column can be null
-        // This should not crash and should fall back to exact matching only
         const c1 = new FileCoverage({
             path: '/path/to/file',
             statementMap: {
@@ -1347,15 +1326,13 @@ describe('lenient merge with different end.column values', () => {
             b: {}
         });
 
-        // Should not throw
         c1.merge(c2);
 
-        // Coverage should be merged correctly via exact matching
         const summary = c1.toSummary();
         assert.equal(summary.statements.total, 2);
         assert.equal(summary.statements.covered, 2);
-        assert.equal(c1.s[0], 1); // 1 + 0
-        assert.equal(c1.s[1], 1); // 0 + 1
+        assert.equal(c1.s[0], 1);
+        assert.equal(c1.s[1], 1);
     });
 });
 

--- a/packages/istanbul-lib-coverage/test/file.test.js
+++ b/packages/istanbul-lib-coverage/test/file.test.js
@@ -1124,6 +1124,241 @@ describe('addNearestContainerHits unit coverage', () => {
     });
 });
 
+describe('lenient merge with different end.column values', () => {
+    it('merges coverage when end.column differs between sources', () => {
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+        // Simulate coverage from two different transpilers that produce
+        // different end.column values for the same logical statement
+        const c1 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 50), // end.column = 50
+                1: loc(2, 0, 2, 30)
+            },
+            fnMap: {
+                0: {
+                    name: 'foo',
+                    line: 1,
+                    loc: loc(1, 0, 1, 50) // end.column = 50
+                }
+            },
+            branchMap: {
+                0: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 0, 2, 30), loc(2, 35, 2, 60)]
+                }
+            },
+            s: { 0: 1, 1: 0 },
+            f: { 0: 1 },
+            b: { 0: [1, 0] }
+        });
+
+        const c2 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 55), // end.column = 55 (different!)
+                1: loc(2, 0, 2, 35) // end.column = 35 (different!)
+            },
+            fnMap: {
+                0: {
+                    name: 'foo',
+                    line: 1,
+                    loc: loc(1, 0, 1, 55) // end.column = 55 (different!)
+                }
+            },
+            branchMap: {
+                0: {
+                    type: 'if',
+                    line: 2,
+                    locations: [loc(2, 0, 2, 35), loc(2, 35, 2, 65)] // different end columns
+                }
+            },
+            s: { 0: 0, 1: 1 },
+            f: { 0: 1 },
+            b: { 0: [0, 1] }
+        });
+
+        c1.merge(c2);
+        const summary = c1.toSummary();
+
+        // With lenient matching, both statements should be merged
+        // Statement 0: 1 + 0 = 1 (covered)
+        // Statement 1: 0 + 1 = 1 (covered)
+        assert.deepEqual(summary.statements, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+
+        // Functions should be merged: 1 + 1 = 2
+        assert.deepEqual(summary.functions, {
+            total: 1,
+            covered: 1,
+            skipped: 0,
+            pct: 100
+        });
+        assert.equal(c1.f[0], 2);
+
+        // Branches should be merged: [1, 0] + [0, 1] = [1, 1]
+        assert.deepEqual(summary.branches, {
+            total: 2,
+            covered: 2,
+            skipped: 0,
+            pct: 100
+        });
+    });
+
+    it('only stores first A item when multiple A items share same lenient key', () => {
+        // Test coverage for lines 155-157: if (!aItemsLenient[lenientKey])
+        // When A has multiple items with same lenient key, only the first is stored
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+
+        const c1 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 50), // lenient key: 1|0|1
+                1: loc(1, 0, 1, 60) // lenient key: 1|0|1 (same!) - triggers line 155 false branch
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 2, 1: 3 },
+            f: {},
+            b: {}
+        });
+
+        const c2 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 55) // lenient key: 1|0|1 - matches first A item
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 4 },
+            f: {},
+            b: {}
+        });
+
+        c1.merge(c2);
+
+        // First A item (index 0) should be merged with B's item: 2 + 4 = 6
+        // Second A item (index 1) keeps its original value: 3
+        assert.equal(c1.s[0], 6);
+        assert.equal(c1.s[1], 3);
+        const summary = c1.toSummary();
+        assert.equal(summary.statements.total, 2);
+    });
+
+    it('skips extra B items that share lenient key with A items', () => {
+        // Test coverage for line 210: if (aItemsLenient[lenientKey]) continue;
+        // When B has multiple items with same lenient key as an A item,
+        // only the first B item gets lenient-matched in the first loop.
+        // The second B item should be skipped in the second loop via line 210.
+        const loc = function(sl, sc, el, ec) {
+            return {
+                start: { line: sl, column: sc },
+                end: { line: el, column: ec }
+            };
+        };
+
+        const c1 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 50) // lenient key: 1|0|1
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 5 },
+            f: {},
+            b: {}
+        });
+
+        const c2 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: loc(1, 0, 1, 99), // lenient key: 1|0|1 (same as c1)
+                1: loc(1, 0, 1, 88) // lenient key: 1|0|1 (same as c1) - this triggers line 210
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 3, 1: 7 },
+            f: {},
+            b: {}
+        });
+
+        c1.merge(c2);
+
+        // A's item should be merged with B's first matching item (index 0)
+        // B's second item (index 1) shares same lenient key, should be skipped via line 210
+        const summary = c1.toSummary();
+        assert.equal(summary.statements.total, 1); // Only 1 statement, not 2
+        assert.equal(c1.s[0], 8); // 5 + 3 = 8 (B's item 1 with value 7 is skipped)
+    });
+
+    it('handles null end.column gracefully without crashing', () => {
+        // Test case from Vitest merge-reports: end.column can be null
+        // This should not crash and should fall back to exact matching only
+        const c1 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: {
+                    start: { line: 2, column: 2 },
+                    end: { line: 2, column: null }
+                },
+                1: {
+                    start: { line: 6, column: 2 },
+                    end: { line: 6, column: null }
+                }
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 1, 1: 0 },
+            f: {},
+            b: {}
+        });
+
+        const c2 = new FileCoverage({
+            path: '/path/to/file',
+            statementMap: {
+                0: {
+                    start: { line: 2, column: 2 },
+                    end: { line: 2, column: null }
+                },
+                1: {
+                    start: { line: 6, column: 2 },
+                    end: { line: 6, column: null }
+                }
+            },
+            fnMap: {},
+            branchMap: {},
+            s: { 0: 0, 1: 1 },
+            f: {},
+            b: {}
+        });
+
+        // Should not throw
+        c1.merge(c2);
+
+        // Coverage should be merged correctly via exact matching
+        const summary = c1.toSummary();
+        assert.equal(summary.statements.total, 2);
+        assert.equal(summary.statements.covered, 2);
+        assert.equal(c1.s[0], 1); // 1 + 0
+        assert.equal(c1.s[1], 1); // 0 + 1
+    });
+});
+
 describe('findNearestContainer missing loc defense', () => {
     it('does not throw if loc is missing', () => {
         const loc = (sl, sc, el, ec) => ({


### PR DESCRIPTION
When merging coverage from different transpilers (e.g., Vitest jsdom vs browser tests), the end.column values can differ for the same logical code location. This caused duplicate entries instead of proper merging.

This fix adds lenient matching that ignores end.column when exact match fails. The matching now uses a two-pass approach:
1. Try exact match (start.line|start.column|end.line|end.column)
2. Fall back to lenient match (start.line|start.column|end.line)

This affects statements, functions, and branches via the mergeProp function.

Fixes #719